### PR TITLE
Supports for NodeMemoryPool and Fixed Size Tree Blob

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,17 +16,17 @@ jobs:
       matrix:
         build_type: [Debug, Release]
         os: [macos-latest, ubuntu-latest]
-        cpp_compiler: [g++, clang++]
+        cpp_compiler: [g++-13, clang++]
         include:
           - os: ubuntu-latest
-            c_compiler: gcc
-            cpp_compiler: g++
+            c_compiler: gcc-13
+            cpp_compiler: g++-13
           - os: macos-latest
             c_compiler: clang
             cpp_compiler: clang++
         exclude:
           - os: macos-latest
-            cpp_compiler: g++
+            cpp_compiler: g++-13
           - os: ubuntu-latest
             cpp_compiler: clang++
 

--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ Reference: <span id="ref"></span>
    |   | ConditionNode               Tests a specific condition.
   ```
 
-* **TreeBlob***   <span id="tree-blob"></span> <a href="#ref">[↑]</a>
+* **TreeBlob**   <span id="tree-blob"></span> <a href="#ref">[↑]</a>
 
   A TreeBlob stores the entity-related states data for all nodes in a tree.
 
-  One bt tree and one entity corresponds to a TreeBlob instance.
+  One bt tree and one entity instance correspond to a TreeBlob instance.
 
   There are two kinds of tree blobs:
 
@@ -205,7 +205,7 @@ Reference: <span id="ref"></span>
      This requires compiling the built behavior tree first, executing it, outputting this information, and then filling
      it in the code that defines these FixedTreeBlobs in the entity.
 
-  To declare a stateful bt node on top of tree blob, checkout the following [node-blob](#node-blob).
+  To declare a stateful bt node on top of tree blob, checkout the following [node-blob](#node-blob) section.
 
 * **Action**  <span id="action"></span> <a href="#ref">[↑]</a>
 
@@ -243,9 +243,12 @@ Reference: <span id="ref"></span>
   ```cpp
   class A : public bt::ActionNode {
    public:
-    NodeBlob* GetNodeBlob() const override { return getNodeBlob<ANodeBlob>(); }
     // Every stateful Node class should declare its own Blob type member.
     using Blob = ANodeBlob;
+    // Should override this method, returns a pointer to the base node blob type.
+    // getNodeBlob is a method provided by bt library, defined in class `Node`.
+    NodeBlob* GetNodeBlob() const override { return getNodeBlob<ANodeBlob>(); }
+
     // Use getNodeBlob<ANodeBlob>() to access the pointer to this's node's data blob.
     bt::Status Update(const bt::Context& ctx) override {
         ANodeBlob* b = getNodeBlob<ANodeBlob>();

--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ Reference: <span id="ref"></span>
 
 * **Action**  <span id="action"></span> <a href="#ref">[↑]</a>
 
-  Define a class that inherits from `bt::Action`, and implement the `Update` method:
+  Define a class that inherits from `bt::ActionNode`, and implement the `Update` method:
 
   ```cpp
-  class A : public bt::Action {
+  class A : public bt::ActionNode {
    public:
     // TODO: Implements this
     bt::Status Update(const bt::Context& ctx) override { }
@@ -209,7 +209,7 @@ Reference: <span id="ref"></span>
   And then overrides the interface `GetNodeBlob`:
 
   ```cpp
-  class A : public bt::Action {
+  class A : public bt::ActionNode {
    public:
     NodeBlob* GetNodeBlob() const override { return getNodeBlob<ANodeBlob>(); }
     // Use getNodeBlob<ANodeBlob>() to access the pointer to this's node's data blob.
@@ -228,7 +228,7 @@ Reference: <span id="ref"></span>
 
   And there's no `RUNNING` status for a condition node.
 
-  To implement a "static condition", just define a class derived from class `bt::Condition`, and implements the `Check` method:
+  To implement a "static condition", just define a class derived from class `bt::ConditionNode`, and implements the `Check` method:
 
   ```cpp
   class C : public bt::ConditionNode {
@@ -335,7 +335,7 @@ Reference: <span id="ref"></span>
   for such cases, the class `Node` supports overriding a `Priority` function.
 
   ```cpp
-  class A : public bt::Action {
+  class A : public bt::ActionNode {
    public:
     unsigned int Priority(const bt::Context& ctx) const override {
         // TODO, returns a number > 0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Just copy the header file `bt.h` and include it.
 
 ## Features
 
-1. Nodes store no data states, behaviors and data are separated.
+1. Nodes store no entity-relate data states, behaviors and data are separated.
 
    **Suitable for: multiple entities sharing a same set of behaviors**.
 
@@ -27,6 +27,7 @@ Just copy the header file `bt.h` and include it.
    and supports to extend the builder.
 3. Built-in multiple decorators, and supports custom decorator definition.
 4. Supports composite nodes with priority child nodes, stateful compositors, and random selector.
+5. Also supports continuous memory fixed sized tree blob.
 
 
 ## The Big Picture
@@ -62,8 +63,12 @@ In the entities module:
 
 ```cpp
 struct Entity {
-  // TreeBlob holds all the entity-related stateful data.
-  bt::TreeBlob blob;
+  // A TreeBlob holds all the entity-related stateful data.
+  bt::DynamicTreeBlob blob;
+
+  // or use a fixed size tree blob, will be embeded into the entity struct.
+  // at most 8 nodes x 64 bytes/per node, 2d fixed size array
+  bt::FixedTreeBlob<8, 64> blob;
 };
 ```
 
@@ -95,6 +100,7 @@ Reference: <span id="ref"></span>
 - [Build](#build)
 - [Status](#status)
 - [Node Classification](#classes)
+- [TreeBlob](#tree-blob)
 - Leaf Nodes:
   - [Action](#action)
     - [Stateful Action](#node-blob)
@@ -124,6 +130,7 @@ Reference: <span id="ref"></span>
   - [Ticker Loop](#ticker-loop)
   - [Custom Builder](#custom-builder)
   - [Working with Signals/Events](#signals)
+  - [Tree traversal](#traversal)
 
 * **Build a tree**: <span id="build"></span> <a href="#ref">[↑]</a>:
 
@@ -175,6 +182,31 @@ Reference: <span id="ref"></span>
    |   | ConditionNode               Tests a specific condition.
   ```
 
+* **TreeBlob***   <span id="tree-blob"></span> <a href="#ref">[↑]</a>
+
+  A TreeBlob stores the entity-related states data for all nodes in a tree.
+
+  One bt tree and one entity corresponds to a TreeBlob instance.
+
+  There are two kinds of tree blobs:
+
+  1. `bt::DynamicTreeBlob` contains a vector of dynamically allocated unique pointers to node blobs.
+  2. `bt::FixedTreeBlob` contains a fixed size 2d array.
+
+     ```cpp
+     // NumNodes is the max number of nodes to store.
+     // MaxSizeNodeBlob is the max value of the sizes of node blobs to store.
+     bt::FixedTreeBlob<NumNodes, MaxSizeNodeBlob> blob;
+     ```
+
+     `FixedTreeBlob` performs a bit faster than the `DynamicTreeBlob`.
+
+     These two template parameters can be obtained through the interface `root.NumNodes()` and `MaxSizeNodeBlob()`.
+     This requires compiling the built behavior tree first, executing it, outputting this information, and then filling
+     it in the code that defines these FixedTreeBlobs in the entity.
+
+  To declare a stateful bt node on top of tree blob, checkout the following [node-blob](#node-blob).
+
 * **Action**  <span id="action"></span> <a href="#ref">[↑]</a>
 
   Define a class that inherits from `bt::ActionNode`, and implement the `Update` method:
@@ -212,6 +244,8 @@ Reference: <span id="ref"></span>
   class A : public bt::ActionNode {
    public:
     NodeBlob* GetNodeBlob() const override { return getNodeBlob<ANodeBlob>(); }
+    // Every stateful Node class should declare its own Blob type member.
+    using Blob = ANodeBlob;
     // Use getNodeBlob<ANodeBlob>() to access the pointer to this's node's data blob.
     bt::Status Update(const bt::Context& ctx) override {
         ANodeBlob* b = getNodeBlob<ANodeBlob>();
@@ -664,6 +698,27 @@ Reference: <span id="ref"></span>
     ._()._()._()._().Action<B>()
     .End()
     ;
+  ```
+
+* **Tree traversal** <span id="traversal"></span> <a href="#ref">[↑]</a>
+
+  There's a simple method to traversal a bt tree in a depth-first way, example code:
+
+  ```cpp
+  // Called before touching a `node`, the ptr is the unique_ptr instance holding this node.
+  // Notes that ptr is nullptr for case `node equals root`.
+  bt::TraversalCallback preOrder = [&](bt:Node& node, bt::Ptr<bt::Node>& ptr) {
+      // TODO
+  };
+
+  // Called after the `node` and all of its children are touched.
+  // ptr is the same meaning as previous preOrder callback.
+  bt::TraversalCallback postOrder = [&](bt::Node& node, bt::Ptr<bt::Node>& ptr) {
+      // TODO
+  };
+
+  // And, we can use bt::NullTraversalCallback for empty callback.
+  root.Traverse(preOrder, postOrder, NullNodePtr);
   ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Reference: <span id="ref"></span>
   We can define a `NodeBlob` struct at first:        <span id="node-blob"></span> <a href="#ref">[↑]</a>:
 
   ```cpp
-  struct ANodeBlob : NodeBlob {
+  struct ANodeBlob : bt::NodeBlob {
     // data fields storing entity related data.
     // It's recommended to set a initial value for each field.
   };

--- a/README.zh.md
+++ b/README.zh.md
@@ -59,8 +59,8 @@ root
 
 ```cpp
 struct Entity {
-  // TreeBlob 存储行为树中所有和实体相关的状态数据
-  bt::TreeBlob blob;
+  // DynamicTreeBlob 存储行为树中所有和实体相关的状态数据
+  bt::DynamicTreeBlob blob;
 
   // 或者用一个固定大小的 TreeBlob, 会直接内嵌到 Entity 结构体内
   // 最多 8 个节点 x 每个节点最多64个字节, 固定大小二维数组
@@ -176,7 +176,7 @@ while(...) {
    |   | ConditionNode               条件节点
   ```
 
-* **TreeBlob***   <span id="tree-blob"></span> <a href="#ref">[↑]</a>
+* **TreeBlob**   <span id="tree-blob"></span> <a href="#ref">[↑]</a>
 
   TreeBlob 负责存储一颗行为树的和实体相关的数据.
 
@@ -234,10 +234,13 @@ while(...) {
   ```cpp
   class A : public bt::ActionNode {
    public:
-    NodeBlob* GetNodeBlob() const override { return getNodeBlob<ANodeBlob>(); }
     // 任何一个有实体状态的节点都应该定义一个类型成员, 叫做 Blob
     using Blob = ANodeBlob;
-    // 在这个类的方法中，可以用 getNodeBlob<ANodeBlob>() 来获取数据快的指针, 来查询和修改实体相关的数据。
+    // 需要重载这个方法, 返回一个指向基础类 NodeBlob 类型的指针
+    // getNodeBlob 是 bt.h 提供的方法, 定义在 `Node` 中
+    NodeBlob* GetNodeBlob() const override { return getNodeBlob<ANodeBlob>(); }
+
+    // 在这个类的方法中，可以用 getNodeBlob<ANodeBlob>() 来获取数据块的指针, 来查询和修改实体相关的数据。
     bt::Status Update(const bt::Context& ctx) override {
         ANodeBlob* b = getNodeBlob<ANodeBlob>();
         b->data = 1; // 示例

--- a/README.zh.md
+++ b/README.zh.md
@@ -151,7 +151,7 @@ while(...) {
 
   重要的一点是，行为树本身只存储树的结构信息、不含任何和实体相关的数据。
 
-* 执行状态码 <span id="status"></span> <a href="#a">[↑]</a>:
+* 执行状态码 <span id="status"></span> <a href="#ref">[↑]</a>:
 
   ```cpp
   bt::Status::RUNNING  // 执行中
@@ -159,7 +159,7 @@ while(...) {
   bt::Status::SUCCESS  // 已成功
   ```
 
-* 行为树节点的分类:  <span id="classes"></span> :  <a href="#a">[↑]</a>
+* 行为树节点的分类:  <span id="classes"></span> :  <a href="#ref">[↑]</a>
 
   ```
   Node                               所有节点的基类
@@ -200,7 +200,7 @@ while(...) {
 
   关于如何定义一个使用 TreeBlob 的行为节点, 请看下面的 [node blob](#node-blob).
 
-* **Action**  <span id="action"></span> <a href="#a">[↑]</a>
+* **Action**  <span id="action"></span> <a href="#ref">[↑]</a>
 
   要定义一个 `Action` 节点，只需要继承自 `bt::ActionNode`，并实现方法 `Update`：
 
@@ -250,7 +250,7 @@ while(...) {
 
   对于其他节点来说，要实现一个和实体相关的状态化的节点，都是如法炮制的。
 
-* **Condition**  <span id="condition"></span> <a href="#a">[↑]</a>
+* **Condition**  <span id="condition"></span> <a href="#ref">[↑]</a>
 
   条件节点没有子节点，当它的 `Check()` 方法返回 `true` 时，算作成功。
 
@@ -286,7 +286,7 @@ while(...) {
   ;
   ```
 
-* **Sequence** <span id="sequence"></span> <a href="#a">[↑]</a>
+* **Sequence** <span id="sequence"></span> <a href="#ref">[↑]</a>
 
   顺序节点会依次执行它的所有子节点，如果子节点全部成功，则它会成功，否则会立即失败。
 
@@ -302,7 +302,7 @@ while(...) {
   ;
   ```
 
-* **Selector**  <span id="selector"></span> <a href="#a">[↑]</a>
+* **Selector**  <span id="selector"></span> <a href="#ref">[↑]</a>
 
   选择节点会依次执行它的所有子节点，如果子节点全部失败，则它会失败，否则遇到一个成功的子节点，会立即成功。
 
@@ -320,7 +320,7 @@ while(...) {
   ;
   ```
 
-* **Parallel** <span id="parallel"></span> <a href="#a">[↑]</a>
+* **Parallel** <span id="parallel"></span> <a href="#ref">[↑]</a>
 
   并行节点会并行地执行所有子节点，即每次 `Tick()` 都会对所有子节点跑一次 `Tick()`，然后再综合子节点的运行结果。
   如果所有节点成功，则算作成功，否则如果至少一个子节点执行失败，则算作失败。
@@ -338,7 +338,7 @@ while(...) {
   ;
   ```
 
-* **RandomSelector**  <span id="random-selector"></span> <a href="#a">[↑]</a>
+* **RandomSelector**  <span id="random-selector"></span> <a href="#ref">[↑]</a>
 
   随机选择节点 会随机选择一个子节点来执行，直到遇到成功的。
 
@@ -355,7 +355,7 @@ while(...) {
   ;
   ```
 
-* **Priority**  <span id="priority"></span> <a href="#a">[↑]</a>
+* **Priority**  <span id="priority"></span> <a href="#ref">[↑]</a>
 
   默认的，节点之间是平权的，也就是优先级相等（都预设为 1）。
 
@@ -381,7 +381,7 @@ while(...) {
 
   所有复合节点，包括有状态节点，都会考虑其子节点的 `Priority()` 函数。
 
-* **有状态的组合节点**  <span id="stateful"></span> <a href="#a">[↑]</a>
+* **有状态的组合节点**  <span id="stateful"></span> <a href="#ref">[↑]</a>
 
   三种组合节点都有支持「有状态的」版本：`StatefulSequence`, `StatefulSelector` 和 `StatefulParallel`.
 
@@ -409,7 +409,7 @@ while(...) {
 
   有状态的组合节点的状态数据都存储在了 `NodeBlob` 中。
 
-* `Switch/Case` 是基于 `Selector` 和 `If` 的一种语法糖：  <span id="switchcase"></span> <a href="#a">[↑]</a>
+* `Switch/Case` 是基于 `Selector` 和 `If` 的一种语法糖：  <span id="switchcase"></span> <a href="#ref">[↑]</a>
 
   ```cpp
   // 只有一个 case 会成功，或者全部失败。
@@ -423,16 +423,16 @@ while(...) {
   ```
 
 
-* **Decorators** <span id="decorators"></span> <a href="#a">[↑]</a>
+* **Decorators** <span id="decorators"></span> <a href="#ref">[↑]</a>
 
-  * `If` 只有在它的条件满足时执行其装饰的子节点：  <span id="if"></span> <a href="#a">[↑]</a>
+  * `If` 只有在它的条件满足时执行其装饰的子节点：  <span id="if"></span> <a href="#ref">[↑]</a>
 
     ```cpp
     .If<SomeCondition>()
     ._().Action<Task>()
     ```
 
-  * `Invert()` 会反转其装饰的子节点的执行状态:  <span id="invert"></span> <a href="#a">[↑]</a>
+  * `Invert()` 会反转其装饰的子节点的执行状态:  <span id="invert"></span> <a href="#ref">[↑]</a>
 
     ```cpp
     .Invert()
@@ -444,7 +444,7 @@ while(...) {
     //   FAILURE => SUCCESS
     ```
 
-  * `Repeat(n)` (别名 `Loop`) 会重复执行被修饰的子节点正好 `n` 次, 如果子节点失败，它会立即失败。  <span id="repeat"></span> <a href="#a">[↑]</a>
+  * `Repeat(n)` (别名 `Loop`) 会重复执行被修饰的子节点正好 `n` 次, 如果子节点失败，它会立即失败。  <span id="repeat"></span> <a href="#ref">[↑]</a>
 
     如果把节点从 开始 `RUNNING`、到 `SUCCESS` 或者 `FAILURE` 叫做一轮的话，`Repeat(n)` 的作用就是执行被修饰的子节点 `n` 轮。
 
@@ -454,7 +454,7 @@ while(...) {
     ._().Action<A>()
     ```
 
-  * `Timeout` 会对其修饰的子节点加一个执行时间限制，如果到时间期限子节点仍未返回成功，则它会返回失败，也不再 tick 子节点。   <span id="timeout"></span> <a href="#a">[↑]</a>
+  * `Timeout` 会对其修饰的子节点加一个执行时间限制，如果到时间期限子节点仍未返回成功，则它会返回失败，也不再 tick 子节点。   <span id="timeout"></span> <a href="#ref">[↑]</a>
 
     ```cpp
     using namespace std::chrono_literals;
@@ -463,7 +463,7 @@ while(...) {
     ._().Action<Task>()
     ```
 
-  * `Delay` 会在执行其子节点之前，等待一段时间。   <span id="delay"></span> <a href="#a">[↑]</a>
+  * `Delay` 会在执行其子节点之前，等待一段时间。   <span id="delay"></span> <a href="#ref">[↑]</a>
 
     ```cpp
     using namespace std::chrono_literals;
@@ -472,7 +472,7 @@ while(...) {
     ._().Action<Task>()
     ```
 
-  * `Retry` 在其装饰的子节点执行失败时会发起重试，最多重试 `n` 次，重试间隔是 `interval` 。  <span id="retry"></span> <a href="#a">[↑]</a>
+  * `Retry` 在其装饰的子节点执行失败时会发起重试，最多重试 `n` 次，重试间隔是 `interval` 。  <span id="retry"></span> <a href="#ref">[↑]</a>
 
     下面的代码中，在 `Task` 子树失败时会发起重试，最多执行 3 次，每次重试的间隔是 `1000ms`：
 
@@ -486,7 +486,7 @@ while(...) {
     ._().Action<Task>()
     ```
 
-  * **自定义装饰器**  <a href="#a">[↑]</a>
+  * **自定义装饰器**  <a href="#ref">[↑]</a>
 
     要定义一个自定义的装饰器，可以继承 `bt::DecoratorNode`:
 
@@ -505,7 +505,7 @@ while(...) {
     一些装饰节点需要利用状态化的数据，如果是实体相关的（也就是非行为树结构的数据），那么可以定义一个 `NodeBlob` 来搭配使用。
     方法和 [上面所讲的带状态的 Action 节点](#node-blob) 一样。
 
-* **子树**  <span id="subtree"></span> <a href="#a">[↑]</a>
+* **子树**  <span id="subtree"></span> <a href="#ref">[↑]</a>
 
   一个行为树可以挂载到另一颗行为树上，作为子树存在：
 
@@ -544,7 +544,7 @@ while(...) {
     .End();
   ```
 
-* **Tick 的上下文结构体 `Context`**  <span id="context"></span> <a href="#a">[↑]</a>
+* **Tick 的上下文结构体 `Context`**  <span id="context"></span> <a href="#ref">[↑]</a>
 
   这个结构体会从根节点一路传递到每个被执行到的节点：
 
@@ -559,7 +559,7 @@ while(...) {
   上下文结构体的主要作用，是可以在行为内部接触外部数据，比如世界中的环境信息。
 
 
-* **钩子函数**  <span id="hooks"></span> <a href="#a">[↑]</a>
+* **钩子函数**  <span id="hooks"></span> <a href="#ref">[↑]</a>
 
   对于每个节点，都支持 3 种钩子函数：
 
@@ -578,7 +578,7 @@ while(...) {
   }
   ```
 
-* **可视化**  <span id="visualization"></span> <a href="#a">[↑]</a>
+* **可视化**  <span id="visualization"></span> <a href="#ref">[↑]</a>
 
   `bt.h` 实现了一个简单的实时把行为树运行状态可视化展示的函数，绿色的节点表示正在被 tick 的节点。
 
@@ -591,7 +591,7 @@ while(...) {
   root.Visualize(ctx.seq)
   ```
 
-* **黑板 ?**  <span id="blackboard"></span> <a href="#a">[↑]</a>
+* **黑板 ?**  <span id="blackboard"></span> <a href="#ref">[↑]</a>
 
   实际上，如果不面向非开发人员的话，行为树和黑板是不需要序列化机制的，也就是说，可以直接使用一个 `struct` 来作为黑板，简单而高效：
 
@@ -616,7 +616,7 @@ while(...) {
   }
   ```
 
-* **Tick 循环**   <span id="ticker-loop"></span> <a href="#a">[↑]</a>
+* **Tick 循环**   <span id="ticker-loop"></span> <a href="#ref">[↑]</a>
 
   `bt.h` 中内置了一个简单额 tick 主循环：
 
@@ -624,7 +624,7 @@ while(...) {
   root.TickForever(ctx, 100ms);
   ```
 
-* **自定义行为树的构建器 Builder**  <span id="custom-builder"></span> <a href="#a">[↑]</a>
+* **自定义行为树的构建器 Builder**  <span id="custom-builder"></span> <a href="#ref">[↑]</a>
 
   ```cpp
   // 假设我们要添加一个自定义的装饰节点

--- a/README.zh.md
+++ b/README.zh.md
@@ -171,10 +171,10 @@ while(...) {
 
 * **Action**  <span id="action"></span> <a href="#a">[↑]</a>
 
-  要定义一个 `Action` 节点，只需要继承自 `bt::Action`，并实现方法 `Update`：
+  要定义一个 `Action` 节点，只需要继承自 `bt::ActionNode`，并实现方法 `Update`：
 
   ```cpp
-  class A : public bt::Action {
+  class A : public bt::ActionNode {
    public:
     // TODO: 需要重载 Update 函数
     bt::Status Update(const bt::Context& ctx) override { }
@@ -201,7 +201,7 @@ while(...) {
   然后，实现接口 `GetNodeBlob`:
 
   ```cpp
-  class A : public bt::Action {
+  class A : public bt::ActionNode {
    public:
     NodeBlob* GetNodeBlob() const override { return getNodeBlob<ANodeBlob>(); }
     // 在这个类的方法中，可以用 getNodeBlob<ANodeBlob>() 来获取数据快的指针, 来查询和修改实体相关的数据。
@@ -220,7 +220,7 @@ while(...) {
 
   条件节点也没有 `RUNNING` 的状态。
 
-  要定义一个「静态的」条件节点，可以继承自 `bt::Condition` 类，然后实现 `Check` 方法：
+  要定义一个「静态的」条件节点，可以继承自 `bt::ConditionNode` 类，然后实现 `Check` 方法：
 
   ```cpp
   class C : public bt::ConditionNode {
@@ -329,7 +329,7 @@ while(...) {
   每次要选择最高分的子节点来执行，因此 Node 类支持重载一个  Priority 的函数。
 
   ```cpp
-  class A : public bt::Action {
+  class A : public bt::ActionNode {
    public:
     unsigned int Priority(const bt::Context& ctx) const override {
         // TODO, 返回一个正整数

--- a/README.zh.md
+++ b/README.zh.md
@@ -224,7 +224,7 @@ while(...) {
   如果要实现一个带实体状态的行为节点，可以先定义一个 `NodeBlob` 结构：      <span id="node-blob"></span> <a href="#ref">[↑]</a>:
 
   ```cpp
-  struct ANodeBlob : NodeBlob {
+  struct ANodeBlob : bt::NodeBlob {
     // 数据字段, 建议加上默认值
   };
   ```

--- a/bt.h
+++ b/bt.h
@@ -66,7 +66,7 @@
 //    |   | ActionNode
 //    |   | ConditionNode
 
-// Version: 0.3.1
+// Version: 0.3.5
 
 #ifndef HIT9_BT_H
 #define HIT9_BT_H

--- a/bt.h
+++ b/bt.h
@@ -273,7 +273,8 @@ class Node {
   std::string name;
   // cache priority for current tick.
   unsigned int priorityCurrentTick = 0;
-  unsigned int priorityCurrentTickSeq = 0;
+// tick seq when the priority cache was set.
+  ull priorityCurrentTickSeq = 0;
 
  protected:
   NodeId id = 0;

--- a/bt.h
+++ b/bt.h
@@ -220,6 +220,7 @@ class DynamicTreeBlob final : public ITreeBlob {
     }
     auto p = std::make_unique_for_overwrite<unsigned char[]>(size);
     auto rp = p.get();
+    std::fill_n(rp, size, 0);
     m[idx] = std::move(p);
     e[idx] = true;
     return rp;
@@ -237,6 +238,27 @@ class DynamicTreeBlob final : public ITreeBlob {
   DynamicTreeBlob() {}
 };
 
+///////////////////////////////
+/// unique ptr deleter
+///////////////////////////////
+
+// NodeUniquePtrDeleter is a custom deleter for unique_ptr<Node>.
+template <typename T>
+struct NodeUniquePtrDeleter {
+  // should we skip delete the ptr from heap?
+  // for Node pointers managed in NodePool, is will set to true.
+  bool skip = false;
+  // Default constructor.
+  NodeUniquePtrDeleter(bool skip = false) : skip(skip) {}
+  // implicit conversion from other deleter,
+  // to support unique_ptr<D, NodeUniquePtrDeleter<D>> to unique_ptr<B, NodeUniquePtrDeleter<B>> conversion.
+  template <typename U>
+  NodeUniquePtrDeleter(const NodeUniquePtrDeleter<U>& other) : skip(other.skip) {}
+  void operator()(T* ptr) const noexcept {
+    if (!skip) delete ptr;
+  }
+};
+
 ////////////////////////////
 /// Node
 ////////////////////////////
@@ -250,10 +272,29 @@ class IRootNode {
   virtual int NumNodes() const = 0;
 };
 
+class Node;  // forward declaration.
+
+// Alias
+template <typename T>
+using Ptr = std::unique_ptr<T, NodeUniquePtrDeleter<T>>;
+
+static Ptr<Node> NullNodePtr = nullptr;
+
+template <typename T>
+using PtrList = std::vector<Ptr<T>>;
+
+// Type of the callback function for node traversal.
+// Parameters:
+//   currentNode is the reference to the node current walking.
+//   currentNodePtr is the reference to the unique_ptr holding the current node's pointer.
+//   it's NullNodePtr for a root node.
+using TraversalCallback = std::function<void(Node& currentNode, Ptr<Node>& currentNodePtr)>;
+static TraversalCallback NullTraversalCallback = [](Node&, Ptr<Node>&) {};
+
 // The most base class of all behavior nodes.
 class Node {
  private:
-  std::string_view name;
+  char _name[16];
 
  protected:
   NodeId id = 0;
@@ -299,7 +340,10 @@ class Node {
   // Every stateful Node class should declare its own Blob type member.
   using Blob = NodeBlob;
 
-  Node(std::string_view name = "Node") : name(name) {}
+  Node(std::string_view name = "Node") {
+    memset(_name, 0, 16);
+    memcpy(_name, name.data(), std::min(name.length(), std::size_t(15)));  // keeps trailling 0
+  }
   virtual ~Node() = default;
 
   /////////////////////////////////////////
@@ -311,7 +355,7 @@ class Node {
   // Returns the size of this node, available after tree built.
   std::size_t Size() const { return size; }
   // Returns the name of this node.
-  virtual std::string_view Name() const { return name; }
+  virtual std::string_view Name() const { return std::string_view(_name); }
   // Returns last status of this node.
   bt::Status LastStatus() const { return GetNodeBlob()->lastStatus; }
 
@@ -323,11 +367,13 @@ class Node {
   // API
   /////////////////////////////////////////
 
-  // Type of the callback function for node traversal.
-  using TraversalCallback = std::function<void(Node&)>;
-  // Traverse the subtree of the current node recursively and execute the given function cb.
-  // Pre-Ordering: parent node are touched first, and then its children.
-  virtual void Traverse(TraversalCallback& cb) { cb(*this); }
+  // Traverse the subtree of the current node recursively and execute the given function callback functions.
+  // The callback function pre will be called pre-order, and the post will be called post-order.
+  // Pass NullTraversalCallback for empty callbacks.
+  virtual void Traverse(TraversalCallback& pre, TraversalCallback& post, Ptr<Node>& ptr) {
+    pre(*this, ptr);
+    post(*this, ptr);
+  }
 
   // Main entry function, should be called on every tick.
   Status Tick(const Context& ctx) {
@@ -387,13 +433,6 @@ class Node {
 // Concept TNode for all classes derived from Node.
 template <typename T>
 concept TNode = std::is_base_of_v<Node, T>;
-
-// Alias
-template <typename T>
-using Ptr = std::unique_ptr<T>;
-
-template <typename T>
-using PtrList = std::vector<Ptr<T>>;
 
 ////////////////////////////
 /// Node > LeafNode
@@ -489,9 +528,10 @@ class SingleNode : public InternalNode {
  public:
   SingleNode(std::string_view name = "SingleNode", Ptr<Node> child = nullptr)
       : InternalNode(name), child(std::move(child)) {}
-  void Traverse(TraversalCallback& cb) override {
-    Node::Traverse(cb);
-    child->Traverse(cb);
+  void Traverse(TraversalCallback& pre, TraversalCallback& post, Ptr<Node>& ptr) override {
+    pre(*this, ptr);
+    if (child != nullptr) child->Traverse(pre, post, child);
+    post(*this, ptr);
   }
   std::string_view Validate() const override { return child == nullptr ? "no child node provided" : ""; }
   void Append(Ptr<Node> node) override { child = std::move(node); }
@@ -530,9 +570,11 @@ class CompositeNode : public InternalNode {
   CompositeNode(std::string_view name = "CompositeNode", PtrList<Node>&& cs = {}) : InternalNode(name) {
     children.swap(cs);
   }
-  void Traverse(TraversalCallback& cb) override {
-    Node::Traverse(cb);
-    for (auto& child : children) child->Traverse(cb);
+  void Traverse(TraversalCallback& pre, TraversalCallback& post, Ptr<Node>& ptr) override {
+    pre(*this, ptr);
+    for (auto& child : children)
+      if (child != nullptr) child->Traverse(pre, post, child);
+    post(*this, ptr);
   }
 
   void Append(Ptr<Node> node) override { children.push_back(std::move(node)); }
@@ -988,7 +1030,7 @@ class InvertNode : public DecoratorNode {
 class ConditionalRunNode : public DecoratorNode {
  private:
   // Condition node to check.
-  Ptr<ConditionNode> condition;
+  Ptr<Node> condition;
 
  public:
   ConditionalRunNode(Ptr<ConditionNode> condition = nullptr, std::string_view name = "ConditionalRun",
@@ -996,10 +1038,11 @@ class ConditionalRunNode : public DecoratorNode {
       : DecoratorNode(std::string(name) + '<' + std::string(condition->Name()) + '>', std::move(child)),
         condition(std::move(condition)) {}
 
-  void Traverse(TraversalCallback& cb) override {
-    Node::Traverse(cb);
-    condition->Traverse(cb);
-    child->Traverse(cb);
+  void Traverse(TraversalCallback& pre, TraversalCallback& post, Ptr<Node>& ptr) override {
+    pre(*this, ptr);
+    if (condition != nullptr) condition->Traverse(pre, post, condition);
+    if (child != nullptr) child->Traverse(pre, post, child);
+    post(*this, ptr);
   }
   Status Update(const Context& ctx) override {
     if (condition->Tick(ctx) == Status::SUCCESS) return child->Tick(ctx);
@@ -1167,8 +1210,16 @@ class RetryNode : public DecoratorNode {
 /// Node > SingleNode > RootNode
 ///////////////////////////////////////////////////////////////
 
+class NodePool;  // forward declaration.
+
 // RootNode is a SingleNode.
 class RootNode : public SingleNode, public IRootNode {
+ private:
+  NodePool* pool = nullptr;
+
+  // for access: pool.
+  friend class NodePool;
+
  protected:
   // Current binding tree blob.
   ITreeBlob* blob = nullptr;
@@ -1181,11 +1232,13 @@ class RootNode : public SingleNode, public IRootNode {
   // MaxSizeNodeBlob is the max size of tree node blobs.
   std::size_t maxSizeNodeBlob = 0;
 
-  friend class _InternalBuilderBase;  // for access to n, maxSizeNode, maxSizeNodeBlob;
+  friend class _InternalBuilderBase;  // for access to n, treeSize, maxSizeNode, maxSizeNodeBlob;
 
  public:
   RootNode(std::string_view name = "Root") : SingleNode(name) {}
   Status Update(const Context& ctx) override { return child->Tick(ctx); }
+  // Returns the pool using, nullptr if none.
+  NodePool* Pool() const { return pool; }
 
   //////////////////////////
   /// Blob Apis
@@ -1262,6 +1315,54 @@ class RootNode : public SingleNode, public IRootNode {
   }
 };
 
+// Concept TRootNode for all classes derived from RootNode.
+template <typename T>
+concept TRootNode = std::is_base_of_v<RootNode, T>;
+
+//////////////////////////////////////////////////////////////
+/// NodePool
+///////////////////////////////////////////////////////////////
+
+// NodePool manages a piece of contiguous memory for node allocations.
+// Its main purpose is for less cache misses in runtime node traversal.
+// It's optional to use a memory pool.
+// It's a (n rows) x (m cols) 2d unsigned char array.
+// Where n should be larger than the max number of total tree nodes.
+// m should be larger than the max size of node ever seen.
+class NodePool {
+ private:
+  std::size_t n, m;        // size: n rows x m cols
+  std::size_t offset = 0;  // pointer offset to buf.
+  std::size_t k = 0;       // how many node allocated.
+  std::unique_ptr<unsigned char[]> buf;
+
+ public:
+  NodePool(std::size_t n, std::size_t m) : n(n), m(m) {
+    auto sz = n * m;
+    buf = std::make_unique_for_overwrite<unsigned char[]>(sz);
+    std::fill_n(buf.get(), sz, 0);
+  }
+
+  // Allocates a new node for given type. returns the raw pointer.
+  template <TNode T, typename... Args>
+  T* Allocate(Args... args) {
+    if (k >= n) throw std::runtime_error("bt: pool n not enough");
+    if (sizeof(T) > m) throw std::runtime_error("bt: pool m not enough, at least: " + std::to_string(sizeof(T)));
+    auto p = buf.get() + offset;
+    offset += sizeof(T);
+    k++;
+    return new (p) T(std::forward<Args>(args)...);
+  }
+
+  // Creates a new tree, returns the reference.
+  template <TRootNode T, typename... Args>
+  T& NewTree(Args... args) {
+    auto tree = Allocate<T>(std::forward<Args>(args)...);
+    tree->pool = this;
+    return *tree;
+  }
+};
+
 //////////////////////////////////////////////////////////////
 /// Tree Builder
 ///////////////////////////////////////////////////////////////
@@ -1285,6 +1386,7 @@ class _InternalBuilderBase {
     root->maxSizeNode = rootNodeSize;
     root->maxSizeNodeBlob = blobSize;
   }
+
   template <TNode T>
   void maintainSizeInfoOnNodeAttach(T& node, RootNode* root) {
     node.size = sizeof(T);
@@ -1292,6 +1394,7 @@ class _InternalBuilderBase {
     root->maxSizeNode = std::max(root->maxSizeNode, sizeof(T));
     root->maxSizeNodeBlob = std::max(root->maxSizeNodeBlob, sizeof(typename T::Blob));
   }
+
   void maintainSizeInfoOnSubtreeAttach(RootNode& subtree, RootNode* root) {
     root->treeSize += subtree.treeSize;
     root->maxSizeNode = std::max(root->maxSizeNode, subtree.maxSizeNode);
@@ -1310,8 +1413,8 @@ class _InternalBuilderBase {
   }
   void onSubtreeAttach(RootNode& subtree, RootNode* root) {
     // Resets root in sub tree recursively.
-    Node::TraversalCallback f = [&](Node& node) { maintainNodeBindInfo(node, root); };
-    subtree.Traverse(f);
+    TraversalCallback pre = [&](Node& node, Ptr<Node>& ptr) { maintainNodeBindInfo(node, root); };
+    subtree.Traverse(pre, NullTraversalCallback, NullNodePtr);
     maintainSizeInfoOnSubtreeAttach(subtree, root);
   }
 };
@@ -1322,8 +1425,10 @@ template <typename D = void>
 class Builder : public _InternalBuilderBase {
  private:
   std::stack<InternalNode*> stack;
-  int level;  // indent level to insert new node, starts from 1.
+  // indent level to insert new node, starts from 1.
+  int level;
   RootNode* root = nullptr;
+
   // Validate node.
   void validate(Node* node) {
     auto e = node->Validate();
@@ -1395,7 +1500,10 @@ class Builder : public _InternalBuilderBase {
   // Any node creation should use this function.
   template <TNode T, typename... Args>
   Ptr<T> make(bool skipActtach, Args... args) {
-    auto p = std::make_unique<T>(std::forward<Args>(args)...);
+    auto p = root->Pool() == nullptr
+                 ? Ptr<T>(new T(std::forward<Args>(args)...), NodeUniquePtrDeleter<T>(false))  // from heap
+                 : Ptr<T>(root->Pool()->Allocate<T>(std::forward<Args>(args)...),
+                          NodeUniquePtrDeleter<T>(true));  // from pool
     if (!skipActtach) onNodeAttach<T>(*p, root);
     return p;
   };

--- a/bt.h
+++ b/bt.h
@@ -193,8 +193,8 @@ class FixedTreeBlob final : public ITreeBlob {
 
  protected:
   void* allocate(const std::size_t idx, std::size_t size) override {
-      if (idx >= NumNodes) throw std::runtime_error("bt: FixedTreeBlob NumNodes not enough");
-      if (size > MaxSizeNodeBlob) throw std::runtime_error("bt: FixedTreeBlob MaxSizeNodeBlob not enough");
+    if (idx >= NumNodes) throw std::runtime_error("bt: FixedTreeBlob NumNodes not enough");
+    if (size > MaxSizeNodeBlob) throw std::runtime_error("bt: FixedTreeBlob MaxSizeNodeBlob not enough");
     buf[idx][0] = true;
     return get(idx);
   };
@@ -1162,7 +1162,7 @@ class RootNode : public SingleNode, public IRootNode {
   // Number of nodes on this tree, including the root itself.
   int n = 0;
   // Size of this tree.
-  std::size_t size = 0;
+  std::size_t treeSize = 0;
   // MaxSizeNode is the max size of tree node.
   std::size_t maxSizeNode = 0;
   // MaxSizeNodeBlob is the max size of tree node blobs.
@@ -1194,7 +1194,7 @@ class RootNode : public SingleNode, public IRootNode {
   int NumNodes() const override final { return n; }
   // Returns the total size of the node classes in this tree.
   // Available once the tree is built.
-  std::size_t Size() const { return size; }
+  std::size_t TreeSize() const { return treeSize; }
   // Returns the max size of the node class in this tree.
   // Available once the tree is built.
   std::size_t MaxSizeNode() const { return maxSizeNode; }
@@ -1266,19 +1266,19 @@ class _InternalBuilderBase {
     node.id = ++nextNodeId;
   }
 
-  void maintainSizeInfoOnRootBind(RootNode* root, std::size_t size, std::size_t blobSize) {
-    root->size += size;
-    root->maxSizeNode = size;
+  void maintainSizeInfoOnRootBind(RootNode* root, std::size_t rootNodeSize, std::size_t blobSize) {
+    root->treeSize += rootNodeSize;
+    root->maxSizeNode = rootNodeSize;
     root->maxSizeNodeBlob = blobSize;
   }
   template <TNode T>
   void maintainSizeInfoOnNodeAttach(T& node, RootNode* root) {
-    root->size += sizeof(T);
+    root->treeSize += sizeof(T);
     root->maxSizeNode = std::max(root->maxSizeNode, sizeof(T));
     root->maxSizeNodeBlob = std::max(root->maxSizeNodeBlob, sizeof(typename T::Blob));
   }
   void maintainSizeInfoOnSubtreeAttach(RootNode& subtree, RootNode* root) {
-    root->size += subtree.size;
+    root->treeSize += subtree.treeSize;
     root->maxSizeNode = std::max(root->maxSizeNode, subtree.maxSizeNode);
     root->maxSizeNodeBlob = std::max(root->maxSizeNodeBlob, subtree.maxSizeNodeBlob);
   }

--- a/bt.h
+++ b/bt.h
@@ -273,6 +273,7 @@ class Node {
   std::string name;
   // cache priority for current tick.
   unsigned int priorityCurrentTick = 0;
+  unsigned int priorityCurrentTickSeq = 0;
 
  protected:
   NodeId id = 0;
@@ -345,8 +346,12 @@ class Node {
 
   // Internal method to query priority of this node in current tick.
   unsigned int GetPriorityCurrentTick(const Context& ctx) {
+    if (ctx.seq != priorityCurrentTickSeq) priorityCurrentTick = 0;
     // try cache in this tick firstly.
-    if (!priorityCurrentTick) priorityCurrentTick = Priority(ctx);
+    if (!priorityCurrentTick) {
+      priorityCurrentTick = Priority(ctx);
+      priorityCurrentTickSeq = ctx.seq;
+    }
     return priorityCurrentTick;
   }
 
@@ -378,9 +383,6 @@ class Node {
       OnTerminate(ctx, status);
       b->running = false;  // reset
     }
-
-    // Clears priority for this tick.
-    priorityCurrentTick = 0;
     return status;
   }
 

--- a/bt.h
+++ b/bt.h
@@ -541,7 +541,6 @@ struct _InternalStatefulCompositeNodeBlob : NodeBlob {
 
 // Always skip children that already succeeded or failure during current round.
 class _InternalStatefulCompositeNode : virtual public CompositeNode {
-
  protected:
   bool isParatialConsidered() const override { return true; }
   bool considerable(int i) const override { return !(getNodeBlob<Blob>()->st[i]); }
@@ -999,7 +998,6 @@ struct RepeatNodeBlob : NodeBlob {
 // RepeatNode repeats its child for exactly n times.
 // Fails immediately if its child fails.
 class RepeatNode : public DecoratorNode {
-
  protected:
   // Times to repeat, -1 for forever, 0 for immediately success.
   int n;
@@ -1039,7 +1037,6 @@ struct TimeoutNodeBlob : NodeBlob {
 // Timeout runs its child for at most given duration, fails on timeout.
 template <typename Clock = std::chrono::high_resolution_clock>
 class TimeoutNode : public DecoratorNode {
-
  protected:
   std::chrono::milliseconds duration;
 
@@ -1068,7 +1065,6 @@ struct DelayNodeBlob : NodeBlob {
 // DelayNode runs its child node after given duration.
 template <typename Clock = std::chrono::high_resolution_clock>
 class DelayNode : public DecoratorNode {
-
  protected:
   // Duration to wait.
   std::chrono::milliseconds duration;
@@ -1102,7 +1098,6 @@ struct RetryNodeBlob : NodeBlob {
 // RetryNode retries its child node on failure.
 template <typename Clock = std::chrono::high_resolution_clock>
 class RetryNode : public DecoratorNode {
-
  protected:
   // Max retry times, -1 for unlimited.
   int maxRetries = -1;

--- a/bt.h
+++ b/bt.h
@@ -296,22 +296,35 @@ class Node {
   friend class _InternalBuilderBase;
 
  public:
+  // Every stateful Node class should declare its own Blob type member.
   using Blob = NodeBlob;
 
   Node(std::string_view name = "Node") : name(name) {}
   virtual ~Node() = default;
+
+  /////////////////////////////////////////
+  // Simple Getters
+  /////////////////////////////////////////
+
   // Returns the id of this node.
   NodeId Id() const { return id; }
   // Returns the size of this node, available after tree built.
   std::size_t Size() const { return size; }
-
-  // Type of the callback function for node traversal.
-  using TraversalCallback = std::function<void(Node&)>;
+  // Returns the name of this node.
+  virtual std::string_view Name() const { return name; }
+  // Returns last status of this node.
+  bt::Status LastStatus() const { return GetNodeBlob()->lastStatus; }
 
   // Helps to access the node blob's pointer, which stores the entity-related data and states.
   // Any Node has a NodeBlob class should override this.
   virtual NodeBlob* GetNodeBlob() const { return getNodeBlob<NodeBlob>(); }
 
+  /////////////////////////////////////////
+  // API
+  /////////////////////////////////////////
+
+  // Type of the callback function for node traversal.
+  using TraversalCallback = std::function<void(Node&)>;
   // Traverse the subtree of the current node recursively and execute the given function cb.
   virtual void Traverse(TraversalCallback& cb) { cb(*this); }
 
@@ -333,15 +346,6 @@ class Node {
     }
     return status;
   }
-
-  // Returns the name of this node.
-  virtual std::string_view Name() const { return name; }
-  // Returns last status of this node.
-  bt::Status LastStatus() const { return GetNodeBlob()->lastStatus; }
-
-  // Validate whether the node is builded correctly.
-  // Returns error message, empty string for good.
-  virtual std::string_view Validate() const { return ""; }
 
   /////////////////////////////////////////
   // Public Virtual Functions To Override
@@ -373,6 +377,10 @@ class Node {
 
   // Hook function to be called on a blob's first allocation.
   virtual void OnBlobAllocated(NodeBlob* blob) const {}
+
+  // Validate whether the node is builded correctly.
+  // Returns error message, empty string for good.
+  virtual std::string_view Validate() const { return ""; }
 };
 
 // Concept TNode for all classes derived from Node.

--- a/bt.h
+++ b/bt.h
@@ -193,6 +193,8 @@ class FixedTreeBlob final : public ITreeBlob {
 
  protected:
   void* allocate(const std::size_t idx, std::size_t size) override {
+      if (idx >= NumNodes) throw std::runtime_error("bt: FixedTreeBlob NumNodes not enough");
+      if (size > MaxSizeNodeBlob) throw std::runtime_error("bt: FixedTreeBlob MaxSizeNodeBlob not enough");
     buf[idx][0] = true;
     return get(idx);
   };

--- a/bt.h
+++ b/bt.h
@@ -13,6 +13,7 @@
 //    and supports to extend the builder.
 // 3. Built-in multiple decorators, and supports custom decoration nodes,
 // 4. Supports composite nodes with priority child nodes, and random selector.
+// 5. Also supports continuous memory storage: fixed size blob and node pool.
 //
 // Code Example
 // ~~~~~~~~~~~~
@@ -153,7 +154,7 @@ concept TNodeBlob = std::is_base_of_v<NodeBlob, T>;
 ////////////////////////////
 
 // ITreeBlob is an internal interface base class for FixedTreeBlob and DynamicTreeBlob.
-// TreeBlob stores the entity-related states data for all nodes in a tree.
+// A TreeBlob stores the entity-related states data for all nodes in a tree.
 // One tree blob for one entity.
 class ITreeBlob {
  protected:
@@ -168,6 +169,7 @@ class ITreeBlob {
   virtual void reserve(const std::size_t cap) = 0;
 
  public:
+  virtual ~ITreeBlob() {}
   // Returns a pointer to given NodeBlob B for the node with given id.
   // Allocates if not exist.
   // Parameter cb is an optional function to be called after the blob is first allocated.
@@ -184,7 +186,7 @@ class ITreeBlob {
 };
 
 // FixedTreeBlob is just a continuous buffer, implements ITreeBlob.
-template <std::size_t NumNodes, std::size_t MaxSizeNodeBlob>
+template <std::size_t NumNodes, std::size_t MaxSizeNodeBlob >
 class FixedTreeBlob final : public ITreeBlob {
  private:
   unsigned char buf[NumNodes][MaxSizeNodeBlob + 1];
@@ -232,9 +234,6 @@ class DynamicTreeBlob final : public ITreeBlob {
  public:
   DynamicTreeBlob() {}
 };
-
-// By default, a DynamicTreeBlob names TreeBlob.
-using TreeBlob = DynamicTreeBlob;
 
 ////////////////////////////
 /// Node

--- a/bt.h
+++ b/bt.h
@@ -186,19 +186,19 @@ class ITreeBlob {
 };
 
 // FixedTreeBlob is just a continuous buffer, implements ITreeBlob.
-template <std::size_t NumNodes, std::size_t MaxSizeNodeBlob >
+template <std::size_t NumNodes, std::size_t MaxSizeNodeBlob>
 class FixedTreeBlob final : public ITreeBlob {
  private:
   unsigned char buf[NumNodes][MaxSizeNodeBlob + 1];
 
  protected:
-   void* allocate(const std::size_t idx, std::size_t size) override{
+  void* allocate(const std::size_t idx, std::size_t size) override {
     buf[idx][0] = true;
     return get(idx);
   };
-   bool exist(const std::size_t idx)override { return static_cast<bool>(buf[idx][0]); };
-   void* get(const std::size_t idx)override { return &buf[idx][1]; };
-   void reserve(const std::size_t cap)override{};
+  bool exist(const std::size_t idx) override { return static_cast<bool>(buf[idx][0]); };
+  void* get(const std::size_t idx) override { return &buf[idx][1]; };
+  void reserve(const std::size_t cap) override{};
 
  public:
   FixedTreeBlob() { memset(buf, 0, sizeof(buf)); }
@@ -211,7 +211,7 @@ class DynamicTreeBlob final : public ITreeBlob {
   std::vector<bool> e;                              // index => exist, dynamic
 
  protected:
-   void* allocate(const std::size_t idx, std::size_t size) override{
+  void* allocate(const std::size_t idx, std::size_t size) override {
     if (m.size() <= idx) {
       m.resize(idx + 1);
       e.resize(idx + 1, false);
@@ -222,9 +222,9 @@ class DynamicTreeBlob final : public ITreeBlob {
     e[idx] = true;
     return rp;
   };
-   bool exist(const std::size_t idx) override{ return e.size() > idx && e[idx]; };
-   void* get(const std::size_t idx)override { return m[idx].get(); };
-   void reserve(const std::size_t cap)override {
+  bool exist(const std::size_t idx) override { return e.size() > idx && e[idx]; };
+  void* get(const std::size_t idx) override { return m[idx].get(); };
+  void reserve(const std::size_t cap) override {
     if (m.capacity() < cap) {
       m.reserve(cap);
       e.reserve(cap);
@@ -541,7 +541,6 @@ struct _InternalStatefulCompositeNodeBlob : NodeBlob {
 
 // Always skip children that already succeeded or failure during current round.
 class _InternalStatefulCompositeNode : virtual public CompositeNode {
-  using Blob = _InternalStatefulCompositeNodeBlob;
 
  protected:
   bool isParatialConsidered() const override { return true; }
@@ -549,6 +548,7 @@ class _InternalStatefulCompositeNode : virtual public CompositeNode {
   void skip(const int i) { getNodeBlob<Blob>()->st[i] = true; }
 
  public:
+  using Blob = _InternalStatefulCompositeNodeBlob;
   NodeBlob* GetNodeBlob() const override { return getNodeBlob<Blob>(); }
   void OnTerminate(const Context& ctx, Status status) override {
     auto& t = getNodeBlob<Blob>()->st;
@@ -999,13 +999,13 @@ struct RepeatNodeBlob : NodeBlob {
 // RepeatNode repeats its child for exactly n times.
 // Fails immediately if its child fails.
 class RepeatNode : public DecoratorNode {
-  using Blob = RepeatNodeBlob;
 
  protected:
   // Times to repeat, -1 for forever, 0 for immediately success.
   int n;
 
  public:
+  using Blob = RepeatNodeBlob;
   RepeatNode(int n, std::string_view name = "Repeat", Ptr<Node> child = nullptr)
       : DecoratorNode(name, std::move(child)), n(n) {}
 
@@ -1039,12 +1039,12 @@ struct TimeoutNodeBlob : NodeBlob {
 // Timeout runs its child for at most given duration, fails on timeout.
 template <typename Clock = std::chrono::high_resolution_clock>
 class TimeoutNode : public DecoratorNode {
-  using Blob = TimeoutNodeBlob<Clock>;
 
  protected:
   std::chrono::milliseconds duration;
 
  public:
+  using Blob = TimeoutNodeBlob<Clock>;
   TimeoutNode(std::chrono::milliseconds d, std::string_view name = "Timeout", Ptr<Node> child = nullptr)
       : DecoratorNode(name, std::move(child)), duration(d) {}
 
@@ -1068,13 +1068,13 @@ struct DelayNodeBlob : NodeBlob {
 // DelayNode runs its child node after given duration.
 template <typename Clock = std::chrono::high_resolution_clock>
 class DelayNode : public DecoratorNode {
-  using Blob = DelayNodeBlob<Clock>;
 
  protected:
   // Duration to wait.
   std::chrono::milliseconds duration;
 
  public:
+  using Blob = DelayNodeBlob<Clock>;
   DelayNode(std::chrono::milliseconds duration, std::string_view name = "Delay", Ptr<Node> c = nullptr)
       : DecoratorNode(name, std::move(c)), duration(duration) {}
 
@@ -1102,7 +1102,6 @@ struct RetryNodeBlob : NodeBlob {
 // RetryNode retries its child node on failure.
 template <typename Clock = std::chrono::high_resolution_clock>
 class RetryNode : public DecoratorNode {
-  using Blob = RetryNodeBlob<Clock>;
 
  protected:
   // Max retry times, -1 for unlimited.
@@ -1111,6 +1110,7 @@ class RetryNode : public DecoratorNode {
   std::chrono::milliseconds interval;
 
  public:
+  using Blob = RetryNodeBlob<Clock>;
   RetryNode(int maxRetries, std::chrono::milliseconds interval, std::string_view name = "Retry",
             Ptr<Node> child = nullptr)
       : DecoratorNode(name, std::move(child)), maxRetries(maxRetries), interval(interval) {}

--- a/bt.h
+++ b/bt.h
@@ -381,7 +381,6 @@ class Node {
 
     // Clears priority for this tick.
     priorityCurrentTick = 0;
-    std::cout << "debug1: clear priority " << Name() << std::endl;
     return status;
   }
 

--- a/bt.h
+++ b/bt.h
@@ -259,6 +259,8 @@ class Node {
   NodeId id = 0;
   // holding a pointer to the root.
   IRootNode* root = nullptr;
+  // size of this node, available after tree built.
+  std::size_t size = 0;
 
   // Internal helper method to return the raw pointer to the node blob.
   template <TNodeBlob B>
@@ -290,7 +292,7 @@ class Node {
   friend class SingleNode;
   friend class CompositeNode;
 
-  // friend with _InternalBuilderBase to access member root and id;
+  // friend with _InternalBuilderBase to access member root, size and id;
   friend class _InternalBuilderBase;
 
  public:
@@ -300,6 +302,8 @@ class Node {
   virtual ~Node() = default;
   // Returns the id of this node.
   NodeId Id() const { return id; }
+  // Returns the size of this node, available after tree built.
+  std::size_t Size() const { return size; }
 
   // Type of the callback function for node traversal.
   using TraversalCallback = std::function<void(Node&)>;
@@ -1267,12 +1271,14 @@ class _InternalBuilderBase {
   }
 
   void maintainSizeInfoOnRootBind(RootNode* root, std::size_t rootNodeSize, std::size_t blobSize) {
+    root->size = rootNodeSize;
     root->treeSize += rootNodeSize;
     root->maxSizeNode = rootNodeSize;
     root->maxSizeNodeBlob = blobSize;
   }
   template <TNode T>
   void maintainSizeInfoOnNodeAttach(T& node, RootNode* root) {
+    node.size = sizeof(T);
     root->treeSize += sizeof(T);
     root->maxSizeNode = std::max(root->maxSizeNode, sizeof(T));
     root->maxSizeNodeBlob = std::max(root->maxSizeNodeBlob, sizeof(typename T::Blob));

--- a/bt.h
+++ b/bt.h
@@ -294,8 +294,8 @@ static TraversalCallback NullTraversalCallback = [](Node&, Ptr<Node>&) {};
 // The most base class of all behavior nodes.
 class Node {
  private:
-  // TODO : comment
-  char* _name = nullptr;
+  // TODO: comment why store a stirng_view
+  std::string_view name;
 
  protected:
   NodeId id = 0;
@@ -341,12 +341,8 @@ class Node {
   // Every stateful Node class should declare its own Blob type member.
   using Blob = NodeBlob;
 
-  Node(std::string_view name = "Node") {
-    _name = new char[name.size() + 1];
-    memcpy(_name, name.data(), name.size());
-    _name[name.size()] = '\0';
-  }
-  virtual ~Node() { delete _name; };
+  Node(std::string_view name = "Node") : name(name) {}
+  virtual ~Node() = default;
 
   /////////////////////////////////////////
   // Simple Getters
@@ -357,7 +353,7 @@ class Node {
   // Returns the size of this node, available after tree built.
   std::size_t Size() const { return size; }
   // Returns the name of this node.
-  virtual std::string_view Name() const { return std::string_view(_name); }  // TODO: fix
+  virtual std::string_view Name() const { return name; }
   // Returns last status of this node.
   bt::Status LastStatus() const { return GetNodeBlob()->lastStatus; }
 

--- a/bt.h
+++ b/bt.h
@@ -192,13 +192,13 @@ class FixedTreeBlob final : public ITreeBlob {
   unsigned char buf[NumNodes][MaxSizeNodeBlob + 1];
 
  protected:
-  virtual void* allocate(const std::size_t idx, std::size_t size) {
+   void* allocate(const std::size_t idx, std::size_t size) override{
     buf[idx][0] = true;
     return get(idx);
   };
-  virtual bool exist(const std::size_t idx) { return static_cast<bool>(buf[idx][0]); };
-  virtual void* get(const std::size_t idx) { return &buf[idx][1]; };
-  virtual void reserve(const std::size_t cap){};
+   bool exist(const std::size_t idx)override { return static_cast<bool>(buf[idx][0]); };
+   void* get(const std::size_t idx)override { return &buf[idx][1]; };
+   void reserve(const std::size_t cap)override{};
 
  public:
   FixedTreeBlob() { memset(buf, 0, sizeof(buf)); }
@@ -211,7 +211,7 @@ class DynamicTreeBlob final : public ITreeBlob {
   std::vector<bool> e;                              // index => exist, dynamic
 
  protected:
-  virtual void* allocate(const std::size_t idx, std::size_t size) {
+   void* allocate(const std::size_t idx, std::size_t size) override{
     if (m.size() <= idx) {
       m.resize(idx + 1);
       e.resize(idx + 1, false);
@@ -222,9 +222,9 @@ class DynamicTreeBlob final : public ITreeBlob {
     e[idx] = true;
     return rp;
   };
-  virtual bool exist(const std::size_t idx) { return e.size() > idx && e[idx]; };
-  virtual void* get(const std::size_t idx) { return m[idx].get(); };
-  virtual void reserve(const std::size_t cap) {
+   bool exist(const std::size_t idx) override{ return e.size() > idx && e[idx]; };
+   void* get(const std::size_t idx)override { return m[idx].get(); };
+   void reserve(const std::size_t cap)override {
     if (m.capacity() < cap) {
       m.reserve(cap);
       e.reserve(cap);

--- a/changelog
+++ b/changelog
@@ -18,6 +18,7 @@ Node's name:
 Misc:
 
 * Refactor Traversal api, allow pre and post order callback.
+* Cache priority value inside a tick (performance improvement).
 
 0.3.1
 -----

--- a/changelog
+++ b/changelog
@@ -6,10 +6,6 @@ Support fixed size TreeBlob:
 * Remove name `TreeBlob`, now is DynamicTreeBlob.
 * Split into `DynamicTreeBlob` and `FixedTreeBlob`
 
-Support fixed size memory pool:
-
-* Add `NodePool` class.
-
 Add api for size info:
 
 * Add api for tree: `TreeSize()`, `MaxSizeNode()`, `MaxSizeNodeBlob()`
@@ -17,7 +13,7 @@ Add api for size info:
 
 Node's name:
 
-* Fix Node name (std::string_view issue), use static array for name.
+* Fix Node name (std::string_view issue), use std::string to store name.
 
 Misc:
 

--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@
 -----
 
 * Remove name `TreeBlob`, split into `DynamicTreeBlob` and `FixedTreeBlob`
+* Add api for tree: `TreeSize()`, `MaxSizeNode()`, `MaxSizeNodeBlob()`
 
 0.3.1
 -----

--- a/changelog
+++ b/changelog
@@ -1,3 +1,8 @@
+0.3.5
+-----
+
+* Remove name `TreeBlob`, split into `DynamicTreeBlob` and `FixedTreeBlob`
+
 0.3.1
 -----
 

--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@
 
 * Remove name `TreeBlob`, split into `DynamicTreeBlob` and `FixedTreeBlob`
 * Add api for tree: `TreeSize()`, `MaxSizeNode()`, `MaxSizeNodeBlob()`
+* Add api for node: `Size()`.
 
 0.3.1
 -----

--- a/changelog
+++ b/changelog
@@ -1,9 +1,27 @@
 0.3.5
 -----
 
-* Remove name `TreeBlob`, split into `DynamicTreeBlob` and `FixedTreeBlob`
+Support fixed size TreeBlob:
+
+* Remove name `TreeBlob`, now is DynamicTreeBlob.
+* Split into `DynamicTreeBlob` and `FixedTreeBlob`
+
+Support fixed size memory pool:
+
+* Add `NodePool` class.
+
+Add api for size info:
+
 * Add api for tree: `TreeSize()`, `MaxSizeNode()`, `MaxSizeNodeBlob()`
 * Add api for node: `Size()`.
+
+Node's name:
+
+* Fix Node name (std::string_view issue), use static array for name.
+
+Misc:
+
+* Refactor Traversal api, allow pre and post order callback.
 
 0.3.1
 -----

--- a/example/main.cc
+++ b/example/main.cc
@@ -1,6 +1,4 @@
-#include <chrono>
 #include <cstdlib>
-#include <iostream>
 
 #include "bt.h"
 using namespace std::chrono_literals;
@@ -31,7 +29,7 @@ class C : public bt::ConditionNode {
 
 // Entity
 struct Entity {
-  bt::DynamicTreeBlob blob;
+  bt::FixedTreeBlob<64, 64> blob;
 };
 
 int main(void) {

--- a/example/main.cc
+++ b/example/main.cc
@@ -31,7 +31,7 @@ class C : public bt::ConditionNode {
 
 // Entity
 struct Entity {
-  bt::TreeBlob blob;
+  bt::DynamicTreeBlob blob;
 };
 
 int main(void) {

--- a/example/onsignal/main.cc
+++ b/example/onsignal/main.cc
@@ -104,7 +104,7 @@ class MyTree : public bt::RootNode, public bt::Builder<MyTree> {
 int main(void) {
   MyTree root("Root");
 
-  bt::TreeBlob blob;
+  bt::DynamicTreeBlob blob;
 
   // clang-format off
   root

--- a/example/onsignal/main.cc
+++ b/example/onsignal/main.cc
@@ -55,7 +55,7 @@ class OnSignalNode : public bt::DecoratorNode {
 };
 
 // Action A prints a simple statement.
-class A : public bt::Action {
+class A : public bt::ActionNode {
  public:
   std::string_view Name() const override { return "A"; }
   bt::Status Update(const bt::Context& ctx) override {
@@ -67,7 +67,7 @@ class A : public bt::Action {
 };
 
 // Action B prints a simple statement.
-class B : public bt::Action {
+class B : public bt::ActionNode {
  public:
   std::string_view Name() const override { return "B"; }
   bt::Status Update(const bt::Context& ctx) override {
@@ -79,7 +79,7 @@ class B : public bt::Action {
 };
 
 // Action C emits signals randomly.
-class C : public bt::Action {
+class C : public bt::ActionNode {
  public:
   std::string_view Name() const override { return "C"; }
   bt::Status Update(const bt::Context& ctx) override {

--- a/tests/blob_test.cc
+++ b/tests/blob_test.cc
@@ -1,3 +1,4 @@
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <functional>
 
@@ -39,22 +40,23 @@ TEST_CASE("Blob/1", "[simple tree blob test]") {
   REQUIRE(p5->lastStatus == bt::Status::RUNNING);
 }
 
-TEST_CASE("Blob/2", "[multiple entites]") {
+TEMPLATE_TEST_CASE("Blob/2", "[multiple entites]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::StatefulSelectorNode::Blob)>)) {
   bt::Tree root;
 
   // clang-format off
   root
   .StatefulSelector()
-  ._().Action<A>()
-  ._().Action<B>()
-  ._().Action<E>()
+  ._().template Action<A>()
+  ._().template Action<B>()
+  ._().template Action<E>()
   .End();
   // clang-format on
 
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
 
-  Entity e1, e2, e3;
+  TestType e1, e2, e3;
 
   // e1: Tick#1
   root.BindTreeBlob(e1.blob);

--- a/tests/blob_test.cc
+++ b/tests/blob_test.cc
@@ -5,7 +5,7 @@
 #include "types.h"
 
 TEST_CASE("Blob/1", "[simple tree blob test]") {
-  bt::TreeBlob blob;
+  bt::DynamicTreeBlob blob;
   std::function<void(bt::NodeBlob*)> cb = nullptr;
 
   // Allocate one

--- a/tests/blob_test.cc
+++ b/tests/blob_test.cc
@@ -47,9 +47,9 @@ TEMPLATE_TEST_CASE("Blob/2", "[multiple entites]", Entity,
   // clang-format off
   root
   .StatefulSelector()
-  ._().template Action<A>()
-  ._().template Action<B>()
-  ._().template Action<E>()
+  ._().Action<A>()
+  ._().Action<B>()
+  ._().Action<E>()
   .End();
   // clang-format on
 

--- a/tests/blob_test.cc
+++ b/tests/blob_test.cc
@@ -61,6 +61,7 @@ TEMPLATE_TEST_CASE("Blob/2", "[multiple entites]", Entity,
   // e1: Tick#1
   root.BindTreeBlob(e1.blob);
   bb->shouldA = bt::Status::FAILURE;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   REQUIRE(bb->counterA == 1);
@@ -71,6 +72,7 @@ TEMPLATE_TEST_CASE("Blob/2", "[multiple entites]", Entity,
   // e2: Tick#1
   root.BindTreeBlob(e2.blob);
   bb->shouldA = bt::Status::SUCCESS;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
   REQUIRE(bb->counterA == 2);  // +1
@@ -81,6 +83,7 @@ TEMPLATE_TEST_CASE("Blob/2", "[multiple entites]", Entity,
   root.BindTreeBlob(e3.blob);
   bb->shouldA = bt::Status::FAILURE;
   bb->shouldB = bt::Status::FAILURE;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   REQUIRE(bb->counterA == 3);  // +1
@@ -92,6 +95,7 @@ TEMPLATE_TEST_CASE("Blob/2", "[multiple entites]", Entity,
   // e1: Tick#2
   root.BindTreeBlob(e1.blob);
   bb->shouldB = bt::Status::FAILURE;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   REQUIRE(bb->counterA == 3);  // +0
@@ -102,6 +106,7 @@ TEMPLATE_TEST_CASE("Blob/2", "[multiple entites]", Entity,
   // e2: Tick#2
   root.BindTreeBlob(e2.blob);
   bb->shouldA = bt::Status::SUCCESS;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
   REQUIRE(bb->counterA == 4);  // +1
@@ -112,6 +117,7 @@ TEMPLATE_TEST_CASE("Blob/2", "[multiple entites]", Entity,
   // e3: Tick#2
   root.BindTreeBlob(e3.blob);
   bb->shouldE = bt::Status::FAILURE;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
   REQUIRE(bb->counterA == 4);  // +0

--- a/tests/builder_test.cc
+++ b/tests/builder_test.cc
@@ -47,6 +47,7 @@ TEMPLATE_TEST_CASE("Builder/1", "[extend a custom decorator to builder]", Entity
   // Tick#1
 
   root.BindTreeBlob(e.blob);
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->customDecoratorCounter == 1);
@@ -55,6 +56,7 @@ TEMPLATE_TEST_CASE("Builder/1", "[extend a custom decorator to builder]", Entity
   // Tick#2
   root.BindTreeBlob(e.blob);
   bb->shouldA = bt::Status::SUCCESS;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 1);

--- a/tests/builder_test.cc
+++ b/tests/builder_test.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <any>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -105,7 +106,7 @@ TEST_CASE("Builder/2", "[node id increment]") {
   root.Traverse(f, bt::NullTraversalCallback, bt::NullNodePtr);
 }
 
-TEST_CASE("Builder/3", "[node count]") {
+TEST_CASE("Builder/3", "[node count and size info]") {
   auto st = [&]() {  // n: 4
     bt::Tree subtree("Subtree");
     // clang-format off
@@ -142,6 +143,22 @@ TEST_CASE("Builder/3", "[node count]") {
   REQUIRE(root.NumNodes() == 18);
 
   // All id should <= n;
-  bt::TraversalCallback cb1 = [&](bt::Node& node,bt::Ptr<bt::Node>& ptr) { REQUIRE(node.Id() <= root.NumNodes()); };
-  root.Traverse(cb1, bt::NullTraversalCallback,bt::NullNodePtr);
+  bt::TraversalCallback cb1 = [&](bt::Node& node, bt::Ptr<bt::Node>& ptr) {
+    REQUIRE(node.Id() <= root.NumNodes());
+  };
+  root.Traverse(cb1, bt::NullTraversalCallback, bt::NullNodePtr);
+
+  // Test total size
+  std::size_t totalSize = 0;
+  std::size_t maxSize = 0;
+  bt::TraversalCallback cb2 = [&](bt::Node& node, bt::Ptr<bt::Node>& ptr) {
+    totalSize += node.Size();
+    maxSize = std::max(node.Size(), maxSize);
+  };
+  root.Traverse(cb2, bt::NullTraversalCallback, bt::NullNodePtr);
+  REQUIRE(totalSize == root.TreeSize());
+  REQUIRE(maxSize == root.MaxSizeNode());
+
+  REQUIRE(root.MaxSizeNodeBlob() == sizeof(bt::NodeBlob));
+  REQUIRE(root.Size() == sizeof(bt::Tree));
 }

--- a/tests/builder_test.cc
+++ b/tests/builder_test.cc
@@ -96,11 +96,11 @@ TEST_CASE("Builder/2", "[node id increment]") {
   // clang-format on
 
   std::unordered_set<bt::NodeId> ids;
-  bt::Node::TraversalCallback f = [&](bt::Node& node) {
+  bt::TraversalCallback f = [&](bt::Node& node, bt::Ptr<bt::Node>& ptr) {
     REQUIRE(ids.find(node.Id()) == ids.end());
     ids.insert(node.Id());
   };
-  root.Traverse(f);
+  root.Traverse(f, bt::NullTraversalCallback, bt::NullNodePtr);
 }
 
 TEST_CASE("Builder/3", "[node count]") {
@@ -140,6 +140,6 @@ TEST_CASE("Builder/3", "[node count]") {
   REQUIRE(root.NumNodes() == 18);
 
   // All id should <= n;
-  bt::Node::TraversalCallback cb1 = [&](bt::Node& node) { REQUIRE(node.Id() <= root.NumNodes()); };
-  root.Traverse(cb1);
+  bt::TraversalCallback cb1 = [&](bt::Node& node,bt::Ptr<bt::Node>& ptr) { REQUIRE(node.Id() <= root.NumNodes()); };
+  root.Traverse(cb1, bt::NullTraversalCallback,bt::NullNodePtr);
 }

--- a/tests/builder_test.cc
+++ b/tests/builder_test.cc
@@ -35,9 +35,9 @@ TEMPLATE_TEST_CASE("Builder/1", "[extend a custom decorator to builder]", Entity
   root
   .Sequence()
   ._().Counter()
-  ._()._().template Action<A>()
+  ._()._().Action<A>()
   ._().Counter()
-  ._()._().template Action<B>()
+  ._()._().Action<B>()
   .End()
   ;
   // clang-format on

--- a/tests/condition_test.cc
+++ b/tests/condition_test.cc
@@ -25,6 +25,7 @@ TEST_CASE("Condition/1", "[simplest condition - constructed from template]") {
   // Tick#1
   root.BindTreeBlob(e.blob);
   std::cout << "tick1" << std::endl;
+  ++ctx.seq;
   root.Tick(ctx);
   // A should not started.
   REQUIRE(bb->counterA == 0);
@@ -35,6 +36,7 @@ TEST_CASE("Condition/1", "[simplest condition - constructed from template]") {
   // Tick#2: Make C true.
   root.BindTreeBlob(e.blob);
   bb->shouldC = true;
+  ++ctx.seq;
   root.Tick(ctx);
   // A should started running.
   REQUIRE(bb->counterA == 1);
@@ -47,6 +49,7 @@ TEST_CASE("Condition/1", "[simplest condition - constructed from template]") {
   // Tick#3: Make A Success.
   root.BindTreeBlob(e.blob);
   bb->shouldA = bt::Status::SUCCESS;
+  ++ctx.seq;
   root.Tick(ctx);
   // The whole tree should Success.
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
@@ -76,6 +79,7 @@ TEST_CASE("Condition/2", "[simplest condition - constructed from lambda]") {
   // Tick#1
   root.BindTreeBlob(e.blob);
 
+  ++ctx.seq;
   root.Tick(ctx);
   // A should not started.
   REQUIRE(bb->counterA == 0);
@@ -83,6 +87,7 @@ TEST_CASE("Condition/2", "[simplest condition - constructed from lambda]") {
 
   // Tick#2: Make C true.
   bb->shouldC = true;
+  ++ctx.seq;
   root.Tick(ctx);
   // A should started running.
   REQUIRE(bb->counterA == 1);
@@ -114,6 +119,7 @@ TEST_CASE("Condition/3", "[simplest condition - if]") {
   REQUIRE(bb->shouldC == false);
 
   // Tick#1
+  ++ctx.seq;
   root.Tick(ctx);
   // A should not started.
   REQUIRE(bb->counterA == 0);
@@ -121,6 +127,7 @@ TEST_CASE("Condition/3", "[simplest condition - if]") {
 
   // Tick#2: Make C true.
   bb->shouldC = true;
+  ++ctx.seq;
   root.Tick(ctx);
   // A should started running.
   REQUIRE(bb->counterA == 1);
@@ -131,6 +138,7 @@ TEST_CASE("Condition/3", "[simplest condition - if]") {
 
   // Tick#2: Make C false.
   bb->shouldC = false;
+  ++ctx.seq;
   root.Tick(ctx);
   // A should not change.
   REQUIRE(bb->counterA == 1);
@@ -160,11 +168,13 @@ TEST_CASE("Condition/4", "[simplest condition - and]") {
   root.BindTreeBlob(e.blob);
 
   // Tick#1
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
 
   // Tick#2: Make C true.
   bb->shouldC = true;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
 
@@ -172,6 +182,7 @@ TEST_CASE("Condition/4", "[simplest condition - and]") {
   bb->shouldC = true;
   bb->shouldD = true;
   bb->shouldF = true;
+  ++ctx.seq;
   root.Tick(ctx);
   // The whole tree should Success
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
@@ -198,17 +209,20 @@ TEST_CASE("Condition/5", "[simplest condition - or]") {
   root.BindTreeBlob(e.blob);
 
   // Tick#1
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
 
   // Tick#2: Make C true.
   bb->shouldC = true;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
 
   // Tick#3: Make only D true.
   bb->shouldC = false;
   bb->shouldD = true;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
 
@@ -216,6 +230,7 @@ TEST_CASE("Condition/5", "[simplest condition - or]") {
   bb->shouldC = true;
   bb->shouldD = true;
   bb->shouldF = true;
+  ++ctx.seq;
   root.Tick(ctx);
   // The whole tree should Success
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
@@ -240,11 +255,13 @@ TEST_CASE("Condition/6", "[simplest condition - not]") {
   root.BindTreeBlob(e.blob);
 
   // Tick#1
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
 
   // Tick#2: Make C true.
   bb->shouldC = true;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
 
@@ -271,18 +288,21 @@ TEST_CASE("Condition/7", "[simplest condition - not2]") {
   REQUIRE(!bb->shouldC);
 
   // Tick#1
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   REQUIRE(bb->counterA == 1);
 
   // Tick#2: Make A Success.
   bb->shouldA = bt::Status::SUCCESS;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
   REQUIRE(bb->counterA == 2);
 
   // Tick#3: Make C true.
   bb->shouldC = true;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
   REQUIRE(bb->counterA == 2);  // not ticked

--- a/tests/delay_test.cc
+++ b/tests/delay_test.cc
@@ -1,3 +1,4 @@
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <thread>
 
@@ -6,7 +7,8 @@
 
 using namespace std::chrono_literals;
 
-TEST_CASE("Delay/1", "[simple delay]") {
+TEMPLATE_TEST_CASE("Delay/1", "[simple delay]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::DelayNode<>::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -19,7 +21,7 @@ TEST_CASE("Delay/1", "[simple delay]") {
     ;
   // clang-format on
 
-  Entity e;
+  TestType e;
 
   REQUIRE(bb->counterA == 0);
   // Tick#1: A is not started.

--- a/tests/delay_test.cc
+++ b/tests/delay_test.cc
@@ -26,7 +26,7 @@ TEMPLATE_TEST_CASE("Delay/1", "[simple delay]", Entity,
   REQUIRE(bb->counterA == 0);
   // Tick#1: A is not started.
   root.BindTreeBlob(e.blob);
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);;
   REQUIRE(bb->counterA == 0);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   root.UnbindTreeBlob();
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("Delay/1", "[simple delay]", Entity,
 
   // Tick#2: A is started.
   root.BindTreeBlob(e.blob);
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);;
   REQUIRE(bb->counterA == 1);
   root.UnbindTreeBlob();
 }

--- a/tests/hook_test.cc
+++ b/tests/hook_test.cc
@@ -34,7 +34,7 @@ TEMPLATE_TEST_CASE("Hook/2", "[hook OnEnter]", Entity, (EntityFixedBlob<16>)) {
   // clang-format off
     root
     .Parallel()
-    ._().template Action<A>()
+    ._().Action<A>()
     .End()
     ;
   // clang-format on
@@ -54,7 +54,7 @@ TEMPLATE_TEST_CASE("Hook/3", "[hook OnTerminate]", Entity, (EntityFixedBlob<16>)
   // clang-format off
     root
     .Parallel()
-    ._().template Action<A>()
+    ._().Action<A>()
     .End()
     ;
   // clang-format on

--- a/tests/hook_test.cc
+++ b/tests/hook_test.cc
@@ -1,3 +1,4 @@
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "bt.h"
@@ -26,19 +27,19 @@ TEST_CASE("Hook/1", "[hook OnBuild]") {
   REQUIRE(onBuildCalled);
 }
 
-TEST_CASE("Hook/2", "[hook OnEnter]") {
+TEMPLATE_TEST_CASE("Hook/2", "[hook OnEnter]", Entity, (EntityFixedBlob<16>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   // clang-format off
     root
     .Parallel()
-    ._().Action<A>()
+    ._().template Action<A>()
     .End()
     ;
   // clang-format on
 
-  Entity e;
+  TestType e;
 
   root.BindTreeBlob(e.blob);
   root.Tick(ctx);
@@ -46,19 +47,19 @@ TEST_CASE("Hook/2", "[hook OnEnter]") {
   root.UnbindTreeBlob();
 }
 
-TEST_CASE("Hook/3", "[hook OnTerminate]") {
+TEMPLATE_TEST_CASE("Hook/3", "[hook OnTerminate]", Entity, (EntityFixedBlob<16>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   // clang-format off
     root
     .Parallel()
-    ._().Action<A>()
+    ._().template Action<A>()
     .End()
     ;
   // clang-format on
 
-  Entity e;
+  TestType e;
 
   root.BindTreeBlob(e.blob);
   root.Tick(ctx);

--- a/tests/hook_test.cc
+++ b/tests/hook_test.cc
@@ -42,7 +42,7 @@ TEMPLATE_TEST_CASE("Hook/2", "[hook OnEnter]", Entity, (EntityFixedBlob<16>)) {
   TestType e;
 
   root.BindTreeBlob(e.blob);
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->onEnterCalledA);
   root.UnbindTreeBlob();
 }
@@ -62,13 +62,13 @@ TEMPLATE_TEST_CASE("Hook/3", "[hook OnTerminate]", Entity, (EntityFixedBlob<16>)
   TestType e;
 
   root.BindTreeBlob(e.blob);
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(!bb->onTerminatedCalledA);
   root.UnbindTreeBlob();
 
   root.BindTreeBlob(e.blob);
   bb->shouldA = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->onTerminatedCalledA);
   root.UnbindTreeBlob();
 }

--- a/tests/invert_test.cc
+++ b/tests/invert_test.cc
@@ -22,7 +22,7 @@ TEST_CASE("Invert/1", "[invert once]") {
 
   // Tick#1: A is running
   root.BindTreeBlob(e.blob);
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->statusA == bt::Status::RUNNING);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
@@ -31,7 +31,7 @@ TEST_CASE("Invert/1", "[invert once]") {
   // Tick#2: A is success.
   root.BindTreeBlob(e.blob);
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->statusA == bt::Status::SUCCESS);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
@@ -58,7 +58,7 @@ TEST_CASE("Invert/2", "[invert twice]") {
 
   // Tick#1: A is running
   root.BindTreeBlob(e.blob);
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->statusA == bt::Status::RUNNING);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
@@ -67,7 +67,7 @@ TEST_CASE("Invert/2", "[invert twice]") {
   // Tick#2: A is success.
   root.BindTreeBlob(e.blob);
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->statusA == bt::Status::SUCCESS);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);

--- a/tests/parallel_test.cc
+++ b/tests/parallel_test.cc
@@ -23,7 +23,7 @@ TEST_CASE("Parallel/1", "[all success]") {
 
   // Tick#1
   root.BindTreeBlob(e.blob);
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // both A and B should RUNNING
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 1);
@@ -36,7 +36,7 @@ TEST_CASE("Parallel/1", "[all success]") {
   // Tick#2: Makes A SUCCESS.
   root.BindTreeBlob(e.blob);
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should SUCCESS, and b should still running
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 2);
@@ -49,7 +49,7 @@ TEST_CASE("Parallel/1", "[all success]") {
   // Tick#3: Makes B success.
   root.BindTreeBlob(e.blob);
   bb->shouldB = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
 
   REQUIRE(bb->counterA == 3);
   REQUIRE(bb->counterB == 3);
@@ -81,7 +81,7 @@ TEST_CASE("Parallel/2", "[partial success (2nd failure)]") {
   root.BindTreeBlob(e.blob);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // both A and B should RUNNING
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 1);
@@ -92,7 +92,7 @@ TEST_CASE("Parallel/2", "[partial success (2nd failure)]") {
 
   // Tick#2: Makes A SUCCESS.
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should SUCCESS, and b should still running
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 2);
@@ -103,7 +103,7 @@ TEST_CASE("Parallel/2", "[partial success (2nd failure)]") {
 
   // Tick#3: Makes B failure.
   bb->shouldB = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
 
   REQUIRE(bb->counterA == 3);
   REQUIRE(bb->counterB == 3);
@@ -135,7 +135,7 @@ TEST_CASE("Parallel/3", "[partial success (1st failure)]") {
   root.BindTreeBlob(e.blob);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // both A and B should RUNNING
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 1);
@@ -146,7 +146,7 @@ TEST_CASE("Parallel/3", "[partial success (1st failure)]") {
 
   // Tick#2: Makes A FAILURE.
   bb->shouldA = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should FAILURE b should still running
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 2);
@@ -178,7 +178,7 @@ TEST_CASE("Parallel/4", "[all failure]") {
   root.BindTreeBlob(e.blob);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // both A and B should RUNNING
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 1);
@@ -190,7 +190,7 @@ TEST_CASE("Parallel/4", "[all failure]") {
   // Tick#2: Makes A and B FAILURE.
   bb->shouldA = bt::Status::FAILURE;
   bb->shouldB = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A and B shuold both FAILURE
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 2);
@@ -225,7 +225,7 @@ TEST_CASE("Parallel/5", "[priority partial]") {
   bb->shouldPriorityH = 2;
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterG == 1);
   REQUIRE(bb->counterH == 1);
   REQUIRE(bb->statusG == bt::Status::RUNNING);
@@ -235,7 +235,7 @@ TEST_CASE("Parallel/5", "[priority partial]") {
   // Tick#2
   bb->shouldG = bt::Status::FAILURE;
   bb->shouldH = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterG == 2);
   REQUIRE(bb->counterH == 2);
   REQUIRE(bb->statusG == bt::Status::FAILURE);

--- a/tests/random_selector_test.cc
+++ b/tests/random_selector_test.cc
@@ -26,7 +26,10 @@ TEST_CASE("RandomSelector/1", "[simple random selector]") {
   bb->shouldPriorityI = 0;
   bb->shouldPriorityH = 1;
 
-  for (int i = 0; i < 100; i++) ++ctx.seq;root.Tick(ctx);
+  for (int i = 0; i < 100; i++) {
+    ++ctx.seq;
+    root.Tick(ctx);
+  }
   REQUIRE(bb->counterI == 0);  // I should have no chance to get tick
   REQUIRE(bb->counterH == 100);
   // The whole tree should RUNNING
@@ -56,7 +59,8 @@ TEST_CASE("RandomSelector/2", "[simple random selector - equal weights]") {
   bb->shouldPriorityI = 1;
   bb->shouldPriorityH = 1;
 
-  for (int i = 0; i < 100000; i++) ++ctx.seq;root.Tick(ctx);
+  for (int i = 0; i < 100000; i++) {++ctx.seq;
+  root.Tick(ctx);}
   REQUIRE(abs(bb->counterI - bb->counterH) < 3000);  // error < 30%?
   // The whole tree should RUNNING
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);

--- a/tests/random_selector_test.cc
+++ b/tests/random_selector_test.cc
@@ -26,7 +26,7 @@ TEST_CASE("RandomSelector/1", "[simple random selector]") {
   bb->shouldPriorityI = 0;
   bb->shouldPriorityH = 1;
 
-  for (int i = 0; i < 100; i++) root.Tick(ctx);
+  for (int i = 0; i < 100; i++) ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterI == 0);  // I should have no chance to get tick
   REQUIRE(bb->counterH == 100);
   // The whole tree should RUNNING
@@ -56,7 +56,7 @@ TEST_CASE("RandomSelector/2", "[simple random selector - equal weights]") {
   bb->shouldPriorityI = 1;
   bb->shouldPriorityH = 1;
 
-  for (int i = 0; i < 100000; i++) root.Tick(ctx);
+  for (int i = 0; i < 100000; i++) ++ctx.seq;root.Tick(ctx);
   REQUIRE(abs(bb->counterI - bb->counterH) < 3000);  // error < 30%?
   // The whole tree should RUNNING
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);

--- a/tests/repeat_test.cc
+++ b/tests/repeat_test.cc
@@ -1,10 +1,11 @@
-
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "bt.h"
 #include "types.h"
 
-TEST_CASE("Repeat/1", "[simple repeat]") {
+TEMPLATE_TEST_CASE("Repeat/1", "[simple repeat]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::RepeatNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -12,15 +13,15 @@ TEST_CASE("Repeat/1", "[simple repeat]") {
   // clang-format off
     root
     .Parallel()
-    ._().Action<E>()
+    ._().template Action<E>()
     ._().Repeat(2)
     ._()._().Sequence()
-    ._()._()._().Action<A>()
-    ._()._()._().Action<B>()
+    ._()._()._().template Action<A>()
+    ._()._()._().template Action<B>()
     .End()
     ;
   // clang-format on
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
 
   REQUIRE(bb->counterA == 0);

--- a/tests/repeat_test.cc
+++ b/tests/repeat_test.cc
@@ -13,11 +13,11 @@ TEMPLATE_TEST_CASE("Repeat/1", "[simple repeat]", Entity,
   // clang-format off
     root
     .Parallel()
-    ._().template Action<E>()
+    ._().Action<E>()
     ._().Repeat(2)
     ._()._().Sequence()
-    ._()._()._().template Action<A>()
-    ._()._()._().template Action<B>()
+    ._()._()._().Action<A>()
+    ._()._()._().Action<B>()
     .End()
     ;
   // clang-format on

--- a/tests/repeat_test.cc
+++ b/tests/repeat_test.cc
@@ -29,7 +29,7 @@ TEMPLATE_TEST_CASE("Repeat/1", "[simple repeat]", Entity,
   REQUIRE(bb->counterE == 0);
 
   // Tick1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterE == 1);
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 0);  // blocked by A
@@ -39,7 +39,7 @@ TEMPLATE_TEST_CASE("Repeat/1", "[simple repeat]", Entity,
   bb->shouldA = bt::Status::SUCCESS;
   bb->shouldB = bt::Status::SUCCESS;
   bb->shouldE = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterE == 2);
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 1);
@@ -48,7 +48,7 @@ TEMPLATE_TEST_CASE("Repeat/1", "[simple repeat]", Entity,
   // Tick3: A, B goes into RUNNING again.
   bb->shouldA = bt::Status::RUNNING;
   bb->shouldB = bt::Status::RUNNING;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterE == 3);
   REQUIRE(bb->counterA == 3);
   REQUIRE(bb->counterB == 1);                         // blocked by A
@@ -57,7 +57,7 @@ TEMPLATE_TEST_CASE("Repeat/1", "[simple repeat]", Entity,
   // Tick4: A, B both gose into SUCCESS again.
   bb->shouldA = bt::Status::SUCCESS;
   bb->shouldB = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterE == 4);
   REQUIRE(bb->counterA == 4);
   REQUIRE(bb->counterB == 2);                         // blocked by A

--- a/tests/retry_test.cc
+++ b/tests/retry_test.cc
@@ -1,3 +1,4 @@
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <thread>
 
@@ -6,7 +7,8 @@
 
 using namespace std::chrono_literals;
 
-TEST_CASE("Retry/1", "[simple retry success]") {
+TEMPLATE_TEST_CASE("Retry/1", "[simple retry success]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::RetryNode<>::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -14,12 +16,11 @@ TEST_CASE("Retry/1", "[simple retry success]") {
   // clang-format off
     root
     .Retry(3, 30ms)
-    ._().Action<A>()
+    ._().template Action<A>()
     .End()
     ;
   // clang-format on
-
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
 
   // Tick#1
@@ -36,7 +37,8 @@ TEST_CASE("Retry/1", "[simple retry success]") {
   root.UnbindTreeBlob();
 }
 
-TEST_CASE("Retry/2", "[simple retry final failure]") {
+TEMPLATE_TEST_CASE("Retry/2", "[simple retry final failure]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::RetryNode<>::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -44,12 +46,12 @@ TEST_CASE("Retry/2", "[simple retry final failure]") {
   // clang-format off
     root
     .Retry(3, 30ms)
-    ._().Action<A>()
+    ._().template Action<A>()
     .End()
     ;
   // clang-format on
 
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
 
   // Tick#1
@@ -81,7 +83,8 @@ TEST_CASE("Retry/2", "[simple retry final failure]") {
   root.UnbindTreeBlob();
 }
 
-TEST_CASE("Retry/3", "[simple retry final success ]") {
+TEMPLATE_TEST_CASE("Retry/3", "[simple retry final success ]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::RetryNode<>::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -89,12 +92,11 @@ TEST_CASE("Retry/3", "[simple retry final success ]") {
   // clang-format off
     root
     .Retry(3, 30ms)
-    ._().Action<A>()
+    ._().template Action<A>()
     .End()
     ;
   // clang-format on
-
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
 
   // Tick#1
@@ -116,7 +118,8 @@ TEST_CASE("Retry/3", "[simple retry final success ]") {
   root.UnbindTreeBlob();
 }
 
-TEST_CASE("Retry/4", "[simple retry forever ]") {
+TEMPLATE_TEST_CASE("Retry/4", "[simple retry forever ]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::RetryNode<>::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -124,12 +127,12 @@ TEST_CASE("Retry/4", "[simple retry forever ]") {
   // clang-format off
     root
     .RetryForever(1ms)
-    ._().Action<A>()
+    ._().template Action<A>()
     .End()
     ;
   // clang-format on
 
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
 
   // Tick#1

--- a/tests/retry_test.cc
+++ b/tests/retry_test.cc
@@ -24,13 +24,13 @@ TEMPLATE_TEST_CASE("Retry/1", "[simple retry success]", Entity,
   root.BindTreeBlob(e.blob);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: Makes A success.
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
 
@@ -55,13 +55,13 @@ TEMPLATE_TEST_CASE("Retry/2", "[simple retry final failure]", Entity,
   root.BindTreeBlob(e.blob);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: Makes A failure
   bb->shouldA = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
@@ -69,15 +69,15 @@ TEMPLATE_TEST_CASE("Retry/2", "[simple retry final failure]", Entity,
   for (int i = 1; i <= 2; i++) {
     std::this_thread::sleep_for(30ms);
     bb->shouldA = bt::Status::RUNNING;
-    root.Tick(ctx);
+    ++ctx.seq;root.Tick(ctx);
     REQUIRE(root.LastStatus() == bt::Status::RUNNING);
     bb->shouldA = bt::Status::FAILURE;
-    root.Tick(ctx);
+    ++ctx.seq;root.Tick(ctx);
     REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   }
 
   // Next the whole tree should failure.
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
 
   root.UnbindTreeBlob();
@@ -100,20 +100,20 @@ TEMPLATE_TEST_CASE("Retry/3", "[simple retry final success ]", Entity,
   root.BindTreeBlob(e.blob);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: Makes A failure
   bb->shouldA = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#3: Makes A ok.
   std::this_thread::sleep_for(30ms);
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
   root.UnbindTreeBlob();
 }
@@ -136,13 +136,13 @@ TEMPLATE_TEST_CASE("Retry/4", "[simple retry forever ]", Entity,
   root.BindTreeBlob(e.blob);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: Makes A failure
   bb->shouldA = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
@@ -150,7 +150,7 @@ TEMPLATE_TEST_CASE("Retry/4", "[simple retry forever ]", Entity,
   for (int i = 0; i < 30; i++) {
     std::this_thread::sleep_for(1ms);
     bb->shouldA = bt::Status::FAILURE;
-    root.Tick(ctx);
+    ++ctx.seq;root.Tick(ctx);
     REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   }
   root.UnbindTreeBlob();

--- a/tests/retry_test.cc
+++ b/tests/retry_test.cc
@@ -16,7 +16,7 @@ TEMPLATE_TEST_CASE("Retry/1", "[simple retry success]", Entity,
   // clang-format off
     root
     .Retry(3, 30ms)
-    ._().template Action<A>()
+    ._().Action<A>()
     .End()
     ;
   // clang-format on
@@ -46,7 +46,7 @@ TEMPLATE_TEST_CASE("Retry/2", "[simple retry final failure]", Entity,
   // clang-format off
     root
     .Retry(3, 30ms)
-    ._().template Action<A>()
+    ._().Action<A>()
     .End()
     ;
   // clang-format on
@@ -92,7 +92,7 @@ TEMPLATE_TEST_CASE("Retry/3", "[simple retry final success ]", Entity,
   // clang-format off
     root
     .Retry(3, 30ms)
-    ._().template Action<A>()
+    ._().Action<A>()
     .End()
     ;
   // clang-format on
@@ -127,7 +127,7 @@ TEMPLATE_TEST_CASE("Retry/4", "[simple retry forever ]", Entity,
   // clang-format off
     root
     .RetryForever(1ms)
-    ._().template Action<A>()
+    ._().Action<A>()
     .End()
     ;
   // clang-format on

--- a/tests/selector_test.cc
+++ b/tests/selector_test.cc
@@ -22,6 +22,7 @@ TEST_CASE("Selector/1", "[first success]") {
   REQUIRE(bb->counterB == 0);
 
   // Tick#1
+  ++ctx.seq;
   root.Tick(ctx);
   // A is still running, B has not started running.
   REQUIRE(bb->counterA == 1);
@@ -33,6 +34,7 @@ TEST_CASE("Selector/1", "[first success]") {
 
   // Tick#2: Makes A SUCCESS.
   bb->shouldA = bt::Status::SUCCESS;
+  ++ctx.seq;
   root.Tick(ctx);
   // A should SUCCESS, and b should not start running
   REQUIRE(bb->counterA == 2);
@@ -43,6 +45,7 @@ TEST_CASE("Selector/1", "[first success]") {
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
 
   // Tick#3: Nothing changes.
+  ++ctx.seq;
   root.Tick(ctx);
 
   // A should still success, and b should still not started.
@@ -74,6 +77,7 @@ TEST_CASE("Selector/2", "[first failure and second success]") {
   REQUIRE(bb->counterB == 0);
 
   // Tick#1
+  ++ctx.seq;
   root.Tick(ctx);
   // A is still running, B has not started running.
   REQUIRE(bb->counterA == 1);
@@ -85,6 +89,7 @@ TEST_CASE("Selector/2", "[first failure and second success]") {
 
   // Tick#2: Makes A FAILURE.
   bb->shouldA = bt::Status::FAILURE;
+  ++ctx.seq;
   root.Tick(ctx);
   // A should FAILURE, and b should started
   REQUIRE(bb->counterA == 2);
@@ -96,6 +101,7 @@ TEST_CASE("Selector/2", "[first failure and second success]") {
 
   // Tick#3: Makes B SUCCESS
   bb->shouldB = bt::Status::SUCCESS;
+  ++ctx.seq;
   root.Tick(ctx);
 
   // A should still FAILURE, and b should SUCCESS.
@@ -127,6 +133,7 @@ TEST_CASE("Selector/3", "[all failure]") {
   REQUIRE(bb->counterB == 0);
 
   // Tick#1
+  ++ctx.seq;
   root.Tick(ctx);
   // A is still running, B has not started running.
   REQUIRE(bb->counterA == 1);
@@ -138,6 +145,7 @@ TEST_CASE("Selector/3", "[all failure]") {
 
   // Tick#2: Makes A FAILURE.
   bb->shouldA = bt::Status::FAILURE;
+  ++ctx.seq;
   root.Tick(ctx);
   // A should FAILURE, and b should started
   REQUIRE(bb->counterA == 2);
@@ -149,6 +157,7 @@ TEST_CASE("Selector/3", "[all failure]") {
 
   // Tick#3: Makes B FAILURE
   bb->shouldB = bt::Status::FAILURE;
+  ++ctx.seq;
   root.Tick(ctx);
 
   // A should still FAILURE, and b should SUCCESS.
@@ -183,6 +192,7 @@ TEST_CASE("Selector/4", "[priority selector final success]") {
   bb->shouldPriorityG = 1;
   bb->shouldPriorityH = 2;
 
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterG == 0);
   REQUIRE(bb->counterH == 1);
@@ -193,6 +203,7 @@ TEST_CASE("Selector/4", "[priority selector final success]") {
 
   // Tick#2: makes H failure.
   bb->shouldH = bt::Status::FAILURE;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterG == 1);  // G now started.
   REQUIRE(bb->counterH == 2);
@@ -202,12 +213,14 @@ TEST_CASE("Selector/4", "[priority selector final success]") {
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#3: one more tick
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterG == 2);
   REQUIRE(bb->counterH == 3);
 
   // Tick#4: make G success.
   bb->shouldG = bt::Status::SUCCESS;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterG == 3);
   REQUIRE(bb->counterH == 4);
@@ -240,6 +253,7 @@ TEST_CASE("Selector/4", "[priority selector final failure]") {
   bb->shouldPriorityG = 1;
   bb->shouldPriorityH = 2;
 
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterG == 0);
   REQUIRE(bb->counterH == 1);
@@ -250,6 +264,7 @@ TEST_CASE("Selector/4", "[priority selector final failure]") {
 
   // Tick#2: makes H failure.
   bb->shouldH = bt::Status::FAILURE;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterG == 1);  // G now started.
   REQUIRE(bb->counterH == 2);
@@ -260,6 +275,7 @@ TEST_CASE("Selector/4", "[priority selector final failure]") {
 
   // Tick#3: make G failure.
   bb->shouldG = bt::Status::FAILURE;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterG == 2);
   REQUIRE(bb->counterH == 3);
@@ -292,6 +308,7 @@ TEST_CASE("Selector/5", "[priority selector - dynamic]") {
   bb->shouldPriorityG = 1;
   bb->shouldPriorityH = 2;
 
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterG == 0);
   REQUIRE(bb->counterH == 1);
@@ -302,6 +319,7 @@ TEST_CASE("Selector/5", "[priority selector - dynamic]") {
 
   // Tick#2: increase G's priority
   bb->shouldPriorityG = 2;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterG == 1);  // G now started
   REQUIRE(bb->counterH == 1);  // H should not ticked
@@ -312,6 +330,7 @@ TEST_CASE("Selector/5", "[priority selector - dynamic]") {
 
   // Tick#3: increase G's priority
   bb->shouldPriorityG = 3;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterG == 2);  // G now started
   REQUIRE(bb->counterH == 1);  // H should not ticked
@@ -322,6 +341,7 @@ TEST_CASE("Selector/5", "[priority selector - dynamic]") {
 
   // Tick#4: makes H success.
   bb->shouldH = bt::Status::SUCCESS;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterG == 3);  // G now started
   REQUIRE(bb->counterH == 1);  // H still blocked
@@ -332,6 +352,7 @@ TEST_CASE("Selector/5", "[priority selector - dynamic]") {
 
   // Tick$5 makes H's priority highest
   bb->shouldPriorityH = 99;
+  ++ctx.seq;
   root.Tick(ctx);
   REQUIRE(bb->counterG == 3);  // G should be skipped.
   REQUIRE(bb->counterH == 2);

--- a/tests/sequence_test.cc
+++ b/tests/sequence_test.cc
@@ -23,7 +23,7 @@ TEST_CASE("Sequence/1", "[all success]") {
   REQUIRE(bb->counterB == 0);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A is still running, B has not started running.
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 0);
@@ -34,7 +34,7 @@ TEST_CASE("Sequence/1", "[all success]") {
 
   // Tick#2: Makes A success.
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should success, and b should started running
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 1);
@@ -42,7 +42,7 @@ TEST_CASE("Sequence/1", "[all success]") {
   REQUIRE(bb->statusB == bt::Status::RUNNING);
 
   // Tick#3
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should stay success, and b should still running
   REQUIRE(bb->counterA == 3);
   REQUIRE(bb->counterB == 2);
@@ -51,7 +51,7 @@ TEST_CASE("Sequence/1", "[all success]") {
 
   // Tick#3: Make B success.
   bb->shouldB = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should stay success, and b should success.
   REQUIRE(bb->counterA == 4);
   REQUIRE(bb->counterB == 3);
@@ -82,7 +82,7 @@ TEST_CASE("Sequence/2", "[partial failure - first failure]") {
   REQUIRE(bb->counterB == 0);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A is still running, B has not started running.
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 0);
@@ -91,7 +91,7 @@ TEST_CASE("Sequence/2", "[partial failure - first failure]") {
 
   // Tick#2: Makes A failure
   bb->shouldA = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should failure, and b should not started
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 0);
@@ -121,7 +121,7 @@ TEST_CASE("Sequence/3", "[partial failure - last failure]") {
   REQUIRE(bb->counterB == 0);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A is still running, B has not started running.
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 0);
@@ -130,7 +130,7 @@ TEST_CASE("Sequence/3", "[partial failure - last failure]") {
 
   // Tick#2: Makes A SUCCESS.
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should failure, and b should start running
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 1);
@@ -141,7 +141,7 @@ TEST_CASE("Sequence/3", "[partial failure - last failure]") {
 
   // Tick#3: Makes B FAILURE
   bb->shouldB = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
 
   // A should still success, and b should FAILURE
   REQUIRE(bb->counterA == 3);
@@ -178,7 +178,7 @@ TEST_CASE("Sequence/4", "[priority sequence - final success]") {
   bb->shouldPriorityI = 3;
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterI == 1);
   REQUIRE(bb->counterH == 0);
   REQUIRE(bb->counterG == 0);
@@ -189,7 +189,7 @@ TEST_CASE("Sequence/4", "[priority sequence - final success]") {
 
   // Tick#2: makes I success
   bb->shouldI = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterI == 2);
   REQUIRE(bb->counterH == 1);
   REQUIRE(bb->counterG == 0);
@@ -200,7 +200,7 @@ TEST_CASE("Sequence/4", "[priority sequence - final success]") {
 
   // Tick#3: makes H success
   bb->shouldH = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterI == 3);
   REQUIRE(bb->counterH == 2);
   REQUIRE(bb->counterG == 1);
@@ -211,7 +211,7 @@ TEST_CASE("Sequence/4", "[priority sequence - final success]") {
 
   // Tick#4: makes G success
   bb->shouldG = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterI == 4);
   REQUIRE(bb->counterH == 3);
   REQUIRE(bb->counterG == 2);
@@ -247,7 +247,7 @@ TEST_CASE("Sequence/5", "[priority sequence - partial success/failure]") {
   bb->shouldPriorityI = 3;
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterI == 1);
   REQUIRE(bb->counterH == 0);
   REQUIRE(bb->counterG == 0);
@@ -258,7 +258,7 @@ TEST_CASE("Sequence/5", "[priority sequence - partial success/failure]") {
 
   // Tick#2: makes I success
   bb->shouldI = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterI == 2);
   REQUIRE(bb->counterH == 1);
   REQUIRE(bb->counterG == 0);
@@ -269,7 +269,7 @@ TEST_CASE("Sequence/5", "[priority sequence - partial success/failure]") {
 
   // Tick#3: makes H FAILURE
   bb->shouldH = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterI == 3);
   REQUIRE(bb->counterH == 2);
   REQUIRE(bb->counterG == 0);
@@ -305,7 +305,7 @@ TEST_CASE("Sequence/5", "[priority sequence - dynamic]") {
   bb->shouldPriorityI = 3;
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterI == 1);
   REQUIRE(bb->counterH == 0);
   REQUIRE(bb->counterG == 0);
@@ -317,7 +317,7 @@ TEST_CASE("Sequence/5", "[priority sequence - dynamic]") {
   // Tick#2: makes G' and H' s priority higher
   bb->shouldPriorityG = 3;
   bb->shouldPriorityH = 3;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterI == 1);
   REQUIRE(bb->counterH == 0);
   REQUIRE(bb->counterG == 1);
@@ -329,7 +329,7 @@ TEST_CASE("Sequence/5", "[priority sequence - dynamic]") {
   // Tick#2: makes I' s priority higher
   bb->shouldPriorityI = 999;
   bb->shouldI = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterI == 2);
   REQUIRE(bb->counterH == 0);
   REQUIRE(bb->counterG == 2);

--- a/tests/stateful_parallel_test.cc
+++ b/tests/stateful_parallel_test.cc
@@ -27,7 +27,7 @@ TEMPLATE_TEST_CASE("StatefulParallel/1", "[all success]", Entity,
   root.BindTreeBlob(e.blob);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A/B/E all started running
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 1);
@@ -40,7 +40,7 @@ TEMPLATE_TEST_CASE("StatefulParallel/1", "[all success]", Entity,
 
   // Tick#2: Make A SUCCESS
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 2);
   REQUIRE(bb->counterE == 2);
@@ -51,7 +51,7 @@ TEMPLATE_TEST_CASE("StatefulParallel/1", "[all success]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#3
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);  // A should skip this tick
   REQUIRE(bb->counterB == 3);
   REQUIRE(bb->counterE == 3);
@@ -63,7 +63,7 @@ TEMPLATE_TEST_CASE("StatefulParallel/1", "[all success]", Entity,
 
   // Tick#4: Makes B SUCCESS
   bb->shouldB = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);  // not ticked
   REQUIRE(bb->counterB == 4);  // got one more tick.
   REQUIRE(bb->counterE == 4);
@@ -75,7 +75,7 @@ TEMPLATE_TEST_CASE("StatefulParallel/1", "[all success]", Entity,
 
   // Tick#5: Makes E success
   bb->shouldE = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);  // not ticked.
   REQUIRE(bb->counterB == 4);  // not ticked.
   REQUIRE(bb->counterE == 5);  // got one more tick.
@@ -86,7 +86,7 @@ TEMPLATE_TEST_CASE("StatefulParallel/1", "[all success]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
 
   // Tick#6: One more tick should restart from all children
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 3);  // got ticked.
   REQUIRE(bb->counterB == 5);  // got ticked.
   REQUIRE(bb->counterE == 6);  // got ticked.
@@ -116,7 +116,7 @@ TEMPLATE_TEST_CASE("StatefulParallel/2", "[final failure]", Entity,
   REQUIRE(bb->counterB == 0);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A/B/E all started running
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 1);
@@ -129,7 +129,7 @@ TEMPLATE_TEST_CASE("StatefulParallel/2", "[final failure]", Entity,
 
   // Tick#2: Make A SUCCESS
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 2);
   REQUIRE(bb->counterE == 2);
@@ -140,7 +140,7 @@ TEMPLATE_TEST_CASE("StatefulParallel/2", "[final failure]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#3
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);  // A should skip this tick
   REQUIRE(bb->counterB == 3);
   REQUIRE(bb->counterE == 3);
@@ -152,7 +152,7 @@ TEMPLATE_TEST_CASE("StatefulParallel/2", "[final failure]", Entity,
 
   // Tick#4: Makes B failure
   bb->shouldB = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);  // not ticked
   REQUIRE(bb->counterB == 4);  // got one more tick.
   REQUIRE(bb->counterE == 4);  // go ticked
@@ -163,7 +163,7 @@ TEMPLATE_TEST_CASE("StatefulParallel/2", "[final failure]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
 
   // Tick#5: One more tick should restart from all children
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 3);  // got ticked.
   REQUIRE(bb->counterB == 5);  // got ticked.
   REQUIRE(bb->counterE == 5);  // got ticked.

--- a/tests/stateful_parallel_test.cc
+++ b/tests/stateful_parallel_test.cc
@@ -12,9 +12,9 @@ TEMPLATE_TEST_CASE("StatefulParallel/1", "[all success]", Entity,
   // clang-format off
     root
     .StatefulParallel()
-    ._().template Action<A>()
-    ._().template Action<B>()
-    ._().template Action<E>()
+    ._().Action<A>()
+    ._().Action<B>()
+    ._().Action<E>()
     .End()
     ;
   // clang-format on
@@ -102,9 +102,9 @@ TEMPLATE_TEST_CASE("StatefulParallel/2", "[final failure]", Entity,
   // clang-format off
     root
     .StatefulParallel()
-    ._().template Action<A>()
-    ._().template Action<B>()
-    ._().template Action<E>()
+    ._().Action<A>()
+    ._().Action<B>()
+    ._().Action<E>()
     .End()
     ;
   // clang-format on

--- a/tests/stateful_parallel_test.cc
+++ b/tests/stateful_parallel_test.cc
@@ -1,18 +1,20 @@
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "bt.h"
 #include "types.h"
 
-TEST_CASE("StatefulParallel/1", "[all success]") {
+TEMPLATE_TEST_CASE("StatefulParallel/1", "[all success]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::StatefulParallelNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   // clang-format off
     root
     .StatefulParallel()
-    ._().Action<A>()
-    ._().Action<B>()
-    ._().Action<E>()
+    ._().template Action<A>()
+    ._().template Action<B>()
+    ._().template Action<E>()
     .End()
     ;
   // clang-format on
@@ -21,7 +23,7 @@ TEST_CASE("StatefulParallel/1", "[all success]") {
   REQUIRE(bb->counterB == 0);
   REQUIRE(bb->counterB == 0);
 
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
 
   // Tick#1
@@ -92,21 +94,22 @@ TEST_CASE("StatefulParallel/1", "[all success]") {
   root.UnbindTreeBlob();
 }
 
-TEST_CASE("StatefulParallel/2", "[final failure]") {
+TEMPLATE_TEST_CASE("StatefulParallel/2", "[final failure]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::StatefulParallelNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   // clang-format off
     root
     .StatefulParallel()
-    ._().Action<A>()
-    ._().Action<B>()
-    ._().Action<E>()
+    ._().template Action<A>()
+    ._().template Action<B>()
+    ._().template Action<E>()
     .End()
     ;
   // clang-format on
 
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
   REQUIRE(bb->counterA == 0);
   REQUIRE(bb->counterB == 0);

--- a/tests/stateful_random_selector_test.cc
+++ b/tests/stateful_random_selector_test.cc
@@ -1,24 +1,26 @@
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "bt.h"
 #include "types.h"
 
-TEST_CASE("StatefulRandomSelector/1", "[simple stateful random selector]") {
+TEMPLATE_TEST_CASE("StatefulRandomSelector/1", "[simple stateful random selector]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::StatefulRandomSelectorNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   // clang-format off
     root
     .StatefulRandomSelector()
-    ._().Action<H>()
-    ._().Action<I>()
+    ._().template Action<H>()
+    ._().template Action<I>()
     .End()
     ;
   // clang-format on
 
   REQUIRE(bb->counterH == 0);
   REQUIRE(bb->counterI == 0);
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
 
   // Tick#1

--- a/tests/stateful_random_selector_test.cc
+++ b/tests/stateful_random_selector_test.cc
@@ -27,12 +27,12 @@ TEMPLATE_TEST_CASE("StatefulRandomSelector/1", "[simple stateful random selector
   bb->shouldPriorityI = 1;
   bb->shouldPriorityH = 1;
 
-  for (int i = 0; i < 10; i++) root.Tick(ctx);
+  for (int i = 0; i < 10; i++) ++ctx.seq;root.Tick(ctx);
 
   // Makes I failure.
   bb->shouldI = bt::Status::FAILURE;
 
-  for (int i = 0; i < 100; i++) root.Tick(ctx);
+  for (int i = 0; i < 100; i++) ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterI <= 11);  // at most get 11 tick
   REQUIRE(bb->counterH >= 99);  // at least 99 tick
 

--- a/tests/stateful_random_selector_test.cc
+++ b/tests/stateful_random_selector_test.cc
@@ -12,8 +12,8 @@ TEMPLATE_TEST_CASE("StatefulRandomSelector/1", "[simple stateful random selector
   // clang-format off
     root
     .StatefulRandomSelector()
-    ._().template Action<H>()
-    ._().template Action<I>()
+    ._().Action<H>()
+    ._().Action<I>()
     .End()
     ;
   // clang-format on

--- a/tests/stateful_random_selector_test.cc
+++ b/tests/stateful_random_selector_test.cc
@@ -27,12 +27,14 @@ TEMPLATE_TEST_CASE("StatefulRandomSelector/1", "[simple stateful random selector
   bb->shouldPriorityI = 1;
   bb->shouldPriorityH = 1;
 
-  for (int i = 0; i < 10; i++) ++ctx.seq;root.Tick(ctx);
+  for (int i = 0; i < 10; i++) {++ctx.seq;
+  root.Tick(ctx);}
 
   // Makes I failure.
   bb->shouldI = bt::Status::FAILURE;
 
-  for (int i = 0; i < 100; i++) ++ctx.seq;root.Tick(ctx);
+  for (int i = 0; i < 100; i++) {++ctx.seq;
+  root.Tick(ctx);}
   REQUIRE(bb->counterI <= 11);  // at most get 11 tick
   REQUIRE(bb->counterH >= 99);  // at least 99 tick
 

--- a/tests/stateful_selector_test.cc
+++ b/tests/stateful_selector_test.cc
@@ -26,7 +26,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/1", "[final success]", Entity,
   REQUIRE(bb->counterB == 0);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A is still running, B & E has not started running.
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 0);
@@ -39,7 +39,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/1", "[final success]", Entity,
 
   // Tick#2: Make A failure.
   bb->shouldA = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should failure, and B should started running, E should still not started.
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 1);
@@ -51,7 +51,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/1", "[final success]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#3
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should stay failure, but without ticked.
   // B should still running, got one more tick.
   REQUIRE(bb->counterA == 2);
@@ -66,7 +66,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/1", "[final success]", Entity,
 
   // Tick#4: Makes B failure
   bb->shouldB = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);  // not ticked
   REQUIRE(bb->counterB == 3);  // got one more tick.
   // E started running
@@ -79,7 +79,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/1", "[final success]", Entity,
 
   // Tick#5: Makes E success
   bb->shouldE = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);  // not ticked.
   REQUIRE(bb->counterB == 3);  // not ticked.
   REQUIRE(bb->counterE == 2);  // got one more tick.
@@ -90,7 +90,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/1", "[final success]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
 
   // Tick#6: One more tick should restart from the first
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 3);  // got ticked.
   root.UnbindTreeBlob();
 }
@@ -117,7 +117,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/2", "[final failure]", Entity,
   REQUIRE(bb->counterB == 0);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A is still running, B & E has not started running.
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 0);
@@ -130,7 +130,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/2", "[final failure]", Entity,
 
   // Tick#2: Make A failure.
   bb->shouldA = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should failure, and B should started running, E should still not started.
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 1);
@@ -142,7 +142,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/2", "[final failure]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#3
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should stay failure, but without ticked.
   // B should still running, got one more tick.
   REQUIRE(bb->counterA == 2);
@@ -157,7 +157,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/2", "[final failure]", Entity,
 
   // Tick#4: Makes B failure
   bb->shouldB = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);  // not ticked
   REQUIRE(bb->counterB == 3);  // got one more tick.
   // E started running
@@ -170,7 +170,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/2", "[final failure]", Entity,
 
   // Tick#5: Makes E failure
   bb->shouldE = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);  // not ticked.
   REQUIRE(bb->counterB == 3);  // not ticked.
   REQUIRE(bb->counterE == 2);  // got one more tick.
@@ -181,7 +181,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/2", "[final failure]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
 
   // Tick#6: One more tick should restart from the first
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 3);  // got ticked.
   root.UnbindTreeBlob();
 }
@@ -212,7 +212,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/3", "[priority statefule selector final suc
   bb->shouldPriorityI = 3;
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterG == 0);
   REQUIRE(bb->counterH == 0);
   REQUIRE(bb->counterI == 1);
@@ -223,7 +223,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/3", "[priority statefule selector final suc
 
   // Tick#2: Make I failure.
   bb->shouldI = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterG == 0);
   REQUIRE(bb->counterH == 1);
   REQUIRE(bb->counterI == 2);
@@ -234,7 +234,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/3", "[priority statefule selector final suc
 
   // Tick#3: Make H failure.
   bb->shouldH = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterG == 1);
   REQUIRE(bb->counterH == 2);
   REQUIRE(bb->counterI == 2);  // skip ticked
@@ -245,7 +245,7 @@ TEMPLATE_TEST_CASE("StatefulSelector/3", "[priority statefule selector final suc
 
   // Tick#4: Make G SUCCESS.
   bb->shouldG = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterG == 2);
   REQUIRE(bb->counterH == 2);  // skip ticked.
   REQUIRE(bb->counterI == 2);  // skip ticked

--- a/tests/stateful_selector_test.cc
+++ b/tests/stateful_selector_test.cc
@@ -1,23 +1,25 @@
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "bt.h"
 #include "types.h"
 
-TEST_CASE("StatefulSelector/1", "[final success]") {
+TEMPLATE_TEST_CASE("StatefulSelector/1", "[final success]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::StatefulSelectorNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   // clang-format off
     root
     .StatefulSelector()
-    ._().Action<A>()
-    ._().Action<B>()
-    ._().Action<E>()
+    ._().template Action<A>()
+    ._().template Action<B>()
+    ._().template Action<E>()
     .End()
     ;
   // clang-format on
 
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
   REQUIRE(bb->counterA == 0);
   REQUIRE(bb->counterB == 0);
@@ -93,20 +95,21 @@ TEST_CASE("StatefulSelector/1", "[final success]") {
   root.UnbindTreeBlob();
 }
 
-TEST_CASE("StatefulSelector/2", "[final failure]") {
+TEMPLATE_TEST_CASE("StatefulSelector/2", "[final failure]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::StatefulSelectorNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   // clang-format off
     root
     .StatefulSelector()
-    ._().Action<A>()
-    ._().Action<B>()
-    ._().Action<E>()
+    ._().template Action<A>()
+    ._().template Action<B>()
+    ._().template Action<E>()
     .End()
     ;
   // clang-format on
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
 
   REQUIRE(bb->counterA == 0);
@@ -183,20 +186,21 @@ TEST_CASE("StatefulSelector/2", "[final failure]") {
   root.UnbindTreeBlob();
 }
 
-TEST_CASE("StatefulSelector/3", "[priority statefule selector final success]") {
+TEMPLATE_TEST_CASE("StatefulSelector/3", "[priority statefule selector final success]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::StatefulSelectorNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   // clang-format off
     root
     .StatefulSelector()
-    ._().Action<G>()
-    ._().Action<H>()
-    ._().Action<I>()
+    ._().template Action<G>()
+    ._().template Action<H>()
+    ._().template Action<I>()
     .End()
     ;
   // clang-format on
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
 
   REQUIRE(bb->counterG == 0);

--- a/tests/stateful_selector_test.cc
+++ b/tests/stateful_selector_test.cc
@@ -12,9 +12,9 @@ TEMPLATE_TEST_CASE("StatefulSelector/1", "[final success]", Entity,
   // clang-format off
     root
     .StatefulSelector()
-    ._().template Action<A>()
-    ._().template Action<B>()
-    ._().template Action<E>()
+    ._().Action<A>()
+    ._().Action<B>()
+    ._().Action<E>()
     .End()
     ;
   // clang-format on
@@ -103,9 +103,9 @@ TEMPLATE_TEST_CASE("StatefulSelector/2", "[final failure]", Entity,
   // clang-format off
     root
     .StatefulSelector()
-    ._().template Action<A>()
-    ._().template Action<B>()
-    ._().template Action<E>()
+    ._().Action<A>()
+    ._().Action<B>()
+    ._().Action<E>()
     .End()
     ;
   // clang-format on
@@ -194,9 +194,9 @@ TEMPLATE_TEST_CASE("StatefulSelector/3", "[priority statefule selector final suc
   // clang-format off
     root
     .StatefulSelector()
-    ._().template Action<G>()
-    ._().template Action<H>()
-    ._().template Action<I>()
+    ._().Action<G>()
+    ._().Action<H>()
+    ._().Action<I>()
     .End()
     ;
   // clang-format on

--- a/tests/stateful_sequence_test.cc
+++ b/tests/stateful_sequence_test.cc
@@ -26,7 +26,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/1", "[all success]", Entity,
   REQUIRE(bb->counterB == 0);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A is still running, B & E has not started running.
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 0);
@@ -39,7 +39,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/1", "[all success]", Entity,
 
   // Tick#2: Make A success.
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should success, and B should started running, E should still not started.
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 1);
@@ -51,7 +51,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/1", "[all success]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#3
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should stay success, but without ticked.
   // B should still running, got one more tick.
   REQUIRE(bb->counterA == 2);
@@ -66,7 +66,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/1", "[all success]", Entity,
 
   // Tick#4: Makes B success.
   bb->shouldB = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 3);  // got one more tick.
   // E started running
@@ -79,7 +79,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/1", "[all success]", Entity,
 
   // Tick#5: Makes E success
   bb->shouldE = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);  // not ticked.
   REQUIRE(bb->counterB == 3);  // not ticked.
   REQUIRE(bb->counterE == 2);  // got one more tick.
@@ -113,7 +113,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/2", "[paritial failure]", Entity,
   REQUIRE(bb->counterB == 0);
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A is still running, B & E has not started running.
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterB == 0);
@@ -126,7 +126,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/2", "[paritial failure]", Entity,
 
   // Tick#2: Make A success.
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should success, and B should started running, E should still not started.
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterB == 1);
@@ -139,7 +139,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/2", "[paritial failure]", Entity,
 
   // Tick#3: Make B failure
   bb->shouldB = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);  // not ticked
   REQUIRE(bb->counterB == 2);  // got one more tick
   REQUIRE(bb->counterE == 0);  // still not started.
@@ -150,7 +150,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/2", "[paritial failure]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
 
   // Tick#4: The next tick will starts from first child.
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 3);  // restarts from here, got ticked
   root.UnbindTreeBlob();
 }
@@ -177,7 +177,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/3", "[priority StatefulSequence]", Entity,
   bb->shouldPriorityI = 3;
 
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterG == 0);
   REQUIRE(bb->counterH == 0);
   REQUIRE(bb->counterI == 1);
@@ -189,7 +189,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/3", "[priority StatefulSequence]", Entity,
 
   // Tick#2: makes I success.
   bb->shouldI = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterG == 0);
   REQUIRE(bb->counterH == 1);
   REQUIRE(bb->counterI == 2);
@@ -199,7 +199,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/3", "[priority StatefulSequence]", Entity,
   // The whole tree should running.
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   // Tick#3
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterG == 0);
   REQUIRE(bb->counterH == 2);
   REQUIRE(bb->counterI == 2);
@@ -210,7 +210,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/3", "[priority StatefulSequence]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   // Tick#4: Makes G priority highest.
   bb->shouldPriorityG = 9999;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterG == 1);
   REQUIRE(bb->counterH == 2);
   REQUIRE(bb->counterI == 2);
@@ -221,7 +221,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/3", "[priority StatefulSequence]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   // Tick#5: Makes G success.
   bb->shouldG = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterG == 2);
   REQUIRE(bb->counterH == 3);
   REQUIRE(bb->counterI == 2);
@@ -232,7 +232,7 @@ TEMPLATE_TEST_CASE("StatefulSequence/3", "[priority StatefulSequence]", Entity,
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   // Tick#6: Makes H success.
   bb->shouldH = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterG == 2);
   REQUIRE(bb->counterH == 4);
   REQUIRE(bb->counterI == 2);

--- a/tests/stateful_sequence_test.cc
+++ b/tests/stateful_sequence_test.cc
@@ -1,23 +1,25 @@
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "bt.h"
 #include "types.h"
 
-TEST_CASE("StatefulSequence/1", "[all success]") {
+TEMPLATE_TEST_CASE("StatefulSequence/1", "[all success]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::StatefulSequenceNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   // clang-format off
     root
     .StatefulSequence()
-    ._().Action<A>()
-    ._().Action<B>()
-    ._().Action<E>()
+    ._().template Action<A>()
+    ._().template Action<B>()
+    ._().template Action<E>()
     .End()
     ;
   // clang-format on
 
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
   REQUIRE(bb->counterA == 0);
   REQUIRE(bb->counterB == 0);
@@ -89,21 +91,22 @@ TEST_CASE("StatefulSequence/1", "[all success]") {
   root.UnbindTreeBlob();
 }
 
-TEST_CASE("StatefulSequence/2", "[paritial failure]") {
+TEMPLATE_TEST_CASE("StatefulSequence/2", "[paritial failure]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::StatefulSequenceNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   // clang-format off
     root
     .StatefulSequence()
-    ._().Action<A>()
-    ._().Action<B>()
-    ._().Action<E>()
+    ._().template Action<A>()
+    ._().template Action<B>()
+    ._().template Action<E>()
     .End()
     ;
   // clang-format on
 
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
   REQUIRE(bb->counterA == 0);
   REQUIRE(bb->counterB == 0);
@@ -152,20 +155,21 @@ TEST_CASE("StatefulSequence/2", "[paritial failure]") {
   root.UnbindTreeBlob();
 }
 
-TEST_CASE("StatefulSequence/3", "[priority StatefulSequence]") {
+TEMPLATE_TEST_CASE("StatefulSequence/3", "[priority StatefulSequence]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::StatefulSequenceNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   // clang-format off
     root
     .StatefulSequence()
-    ._().Action<G>()
-    ._().Action<H>()
-    ._().Action<I>()
+    ._().template Action<G>()
+    ._().template Action<H>()
+    ._().template Action<I>()
     .End()
     ;
   // clang-format on
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
 
   bb->shouldPriorityG = 1;

--- a/tests/stateful_sequence_test.cc
+++ b/tests/stateful_sequence_test.cc
@@ -12,9 +12,9 @@ TEMPLATE_TEST_CASE("StatefulSequence/1", "[all success]", Entity,
   // clang-format off
     root
     .StatefulSequence()
-    ._().template Action<A>()
-    ._().template Action<B>()
-    ._().template Action<E>()
+    ._().Action<A>()
+    ._().Action<B>()
+    ._().Action<E>()
     .End()
     ;
   // clang-format on
@@ -99,9 +99,9 @@ TEMPLATE_TEST_CASE("StatefulSequence/2", "[paritial failure]", Entity,
   // clang-format off
     root
     .StatefulSequence()
-    ._().template Action<A>()
-    ._().template Action<B>()
-    ._().template Action<E>()
+    ._().Action<A>()
+    ._().Action<B>()
+    ._().Action<E>()
     .End()
     ;
   // clang-format on
@@ -163,9 +163,9 @@ TEMPLATE_TEST_CASE("StatefulSequence/3", "[priority StatefulSequence]", Entity,
   // clang-format off
     root
     .StatefulSequence()
-    ._().template Action<G>()
-    ._().template Action<H>()
-    ._().template Action<I>()
+    ._().Action<G>()
+    ._().Action<H>()
+    ._().Action<I>()
     .End()
     ;
   // clang-format on

--- a/tests/subtree_test.cc
+++ b/tests/subtree_test.cc
@@ -15,7 +15,7 @@ TEMPLATE_TEST_CASE("SubTree/1", "[subtree test]", Entity, (EntityFixedBlob<32>))
   subtree
   .Sequence()
   ._().template Action<A>()
-  ._().If<C>()
+  ._().template If<C>()
   ._()._().template Action<B>()
   .End()
   ;

--- a/tests/subtree_test.cc
+++ b/tests/subtree_test.cc
@@ -14,9 +14,9 @@ TEMPLATE_TEST_CASE("SubTree/1", "[subtree test]", Entity, (EntityFixedBlob<32>))
   // clang-format off
   subtree
   .Sequence()
-  ._().template Action<A>()
-  ._().template If<C>()
-  ._()._().template Action<B>()
+  ._().Action<A>()
+  ._().If<C>()
+  ._()._().Action<B>()
   .End()
   ;
   // clang-format on
@@ -24,7 +24,7 @@ TEMPLATE_TEST_CASE("SubTree/1", "[subtree test]", Entity, (EntityFixedBlob<32>))
   // clang-format off
   root
   .Selector()
-  ._().template Action<E>()
+  ._().Action<E>()
   ._().Subtree(std::move(subtree))
   .End()
   ;

--- a/tests/subtree_test.cc
+++ b/tests/subtree_test.cc
@@ -1,9 +1,10 @@
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "bt.h"
 #include "types.h"
 
-TEST_CASE("SubTree/1", "[subtree test]") {
+TEMPLATE_TEST_CASE("SubTree/1", "[subtree test]", Entity, (EntityFixedBlob<32>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -13,9 +14,9 @@ TEST_CASE("SubTree/1", "[subtree test]") {
   // clang-format off
   subtree
   .Sequence()
-  ._().Action<A>()
+  ._().template Action<A>()
   ._().If<C>()
-  ._()._().Action<B>()
+  ._()._().template Action<B>()
   .End()
   ;
   // clang-format on
@@ -23,13 +24,13 @@ TEST_CASE("SubTree/1", "[subtree test]") {
   // clang-format off
   root
   .Selector()
-  ._().Action<E>()
+  ._().template Action<E>()
   ._().Subtree(std::move(subtree))
   .End()
   ;
   // clang-format on
 
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
 
   // Tick#1: Make Action E Failure.

--- a/tests/subtree_test.cc
+++ b/tests/subtree_test.cc
@@ -35,7 +35,7 @@ TEMPLATE_TEST_CASE("SubTree/1", "[subtree test]", Entity, (EntityFixedBlob<32>))
 
   // Tick#1: Make Action E Failure.
   bb->shouldE = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should running.
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterE == 1);
@@ -44,7 +44,7 @@ TEMPLATE_TEST_CASE("SubTree/1", "[subtree test]", Entity, (EntityFixedBlob<32>))
 
   // Tick#2: Make C true.
   bb->shouldC = true;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterE == 2);
   REQUIRE(bb->counterB == 0);  // B is blocked
@@ -52,7 +52,7 @@ TEMPLATE_TEST_CASE("SubTree/1", "[subtree test]", Entity, (EntityFixedBlob<32>))
 
   // Tick#3: Make A success.
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 3);
   REQUIRE(bb->counterE == 3);
   REQUIRE(bb->counterB == 1);  // B is started
@@ -60,7 +60,7 @@ TEMPLATE_TEST_CASE("SubTree/1", "[subtree test]", Entity, (EntityFixedBlob<32>))
 
   // Tick#4: Make B success.
   bb->shouldB = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 4);
   REQUIRE(bb->counterE == 4);
   REQUIRE(bb->counterB == 2);  // B ok

--- a/tests/switch_case_test.cc
+++ b/tests/switch_case_test.cc
@@ -24,7 +24,7 @@ TEST_CASE("SwitchCase/1", "[simplest switch/case]") {
   Entity e;
   root.BindTreeBlob(e.blob);
   // Tick#1
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // All should unstarted.
   REQUIRE(bb->counterA == 0);
   REQUIRE(bb->counterE == 0);
@@ -34,7 +34,7 @@ TEST_CASE("SwitchCase/1", "[simplest switch/case]") {
 
   // Tick#2: Make D success.
   bb->shouldD = true;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // only B should started
   REQUIRE(bb->counterA == 0);
   REQUIRE(bb->counterE == 0);
@@ -46,7 +46,7 @@ TEST_CASE("SwitchCase/1", "[simplest switch/case]") {
   // Tick#3: Make D FAILURE and C ok
   bb->shouldD = false;
   bb->shouldC = true;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   // A should started
   REQUIRE(bb->counterA == 1);
   REQUIRE(bb->counterE == 0);
@@ -60,7 +60,7 @@ TEST_CASE("SwitchCase/1", "[simplest switch/case]") {
   // Tick#4: Make A success and E success
   bb->shouldA = bt::Status::SUCCESS;
   bb->shouldE = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(bb->counterE == 1);
   REQUIRE(bb->counterB == 1);

--- a/tests/tick_benchmark.cc
+++ b/tests/tick_benchmark.cc
@@ -1,4 +1,5 @@
 #include <catch2/benchmark/catch_benchmark_all.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "bt.h"
@@ -10,11 +11,11 @@ void build(bt::Tree& root) {
   for (int i = 0; i < 1000; i++) {
     // clang-format off
     root
-    ._().Action<A>()
-    ._().Action<B>()
-    ._().Action<G>()
-    ._().Action<H>()
-    ._().Action<I>();
+    ._().template Action<A>()
+    ._().template Action<B>()
+    ._().template Action<G>()
+    ._().template Action<H>()
+    ._().template Action<I>();
     // clang-format on
   }
   root.End();
@@ -26,22 +27,22 @@ void buildStateful(bt::Tree& root) {
   for (int i = 0; i < 1000; i++) {
     // clang-format off
     root
-    ._().Action<A>()
-    ._().Action<B>()
-    ._().Action<G>()
-    ._().Action<H>()
-    ._().Action<I>();
+    ._().template Action<A>()
+    ._().template Action<B>()
+    ._().template Action<G>()
+    ._().template Action<H>()
+    ._().template Action<I>();
     // clang-format on
   }
   root.End();
 }
 
-TEST_CASE("Tick/1", "[simple traversal benchmark ]") {
+TEMPLATE_TEST_CASE("Tick/1", "[simple traversal benchmark ]", Entity, (EntityFixedBlob<6002>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   build(root);
-  Entity e;
+  TestType e;
   bb->shouldA = bt::Status::SUCCESS;
   bb->shouldB = bt::Status::SUCCESS;
   bb->shouldG = bt::Status::SUCCESS;
@@ -87,24 +88,6 @@ TEST_CASE("Tick/3", "[simple traversal benchmark - stateful ]") {
   bb->shouldH = bt::Status::SUCCESS;
   bb->shouldI = bt::Status::SUCCESS;
   BENCHMARK("bench tick without priorities - stateful ") {
-    root.BindTreeBlob(e.blob);
-    root.Tick(ctx);
-    root.UnbindTreeBlob();
-  };
-}
-
-TEST_CASE("Tick/4", "[simple traversal benchmark - fixed blob ]") {
-  bt::Tree root;
-  auto bb = std::make_shared<Blackboard>();
-  bt::Context ctx(bb);
-  build(root);
-  EntityFixedBlob<6002, sizeof(bt::NodeBlob)> e;
-  bb->shouldA = bt::Status::SUCCESS;
-  bb->shouldB = bt::Status::SUCCESS;
-  bb->shouldG = bt::Status::SUCCESS;
-  bb->shouldH = bt::Status::SUCCESS;
-  bb->shouldI = bt::Status::SUCCESS;
-  BENCHMARK("bench tick without priorities - fixed blob ") {
     root.BindTreeBlob(e.blob);
     root.Tick(ctx);
     root.UnbindTreeBlob();

--- a/tests/tick_benchmark.cc
+++ b/tests/tick_benchmark.cc
@@ -98,7 +98,7 @@ TEST_CASE("Tick/4", "[simple traversal benchmark - fixed blob ]") {
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
   build(root);
-  EntityFixedBlob e;
+  EntityFixedBlob<6002, sizeof(bt::NodeBlob)> e;
   bb->shouldA = bt::Status::SUCCESS;
   bb->shouldB = bt::Status::SUCCESS;
   bb->shouldG = bt::Status::SUCCESS;

--- a/tests/tick_benchmark.cc
+++ b/tests/tick_benchmark.cc
@@ -11,11 +11,11 @@ void build(bt::Tree& root) {
   for (int i = 0; i < 1000; i++) {
     // clang-format off
     root
-    ._().template Action<A>()
-    ._().template Action<B>()
-    ._().template Action<G>()
-    ._().template Action<H>()
-    ._().template Action<I>();
+    ._().Action<A>()
+    ._().Action<B>()
+    ._().Action<G>()
+    ._().Action<H>()
+    ._().Action<I>();
     // clang-format on
   }
   root.End();
@@ -27,11 +27,11 @@ void buildStateful(bt::Tree& root) {
   for (int i = 0; i < 1000; i++) {
     // clang-format off
     root
-    ._().template Action<A>()
-    ._().template Action<B>()
-    ._().template Action<G>()
-    ._().template Action<H>()
-    ._().template Action<I>();
+    ._().Action<A>()
+    ._().Action<B>()
+    ._().Action<G>()
+    ._().Action<H>()
+    ._().Action<I>();
     // clang-format on
   }
   root.End();

--- a/tests/tick_benchmark.cc
+++ b/tests/tick_benchmark.cc
@@ -1,14 +1,15 @@
 #include <catch2/benchmark/catch_benchmark_all.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <vector>
 
 #include "bt.h"
 #include "types.h"
 
 // build a large tree.
-void build(bt::Tree& root) {
+void build(bt::Tree& root, int n = 1000) {
   root.Sequence();
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < n; i++) {
     // clang-format off
     root
     ._().Action<A>()
@@ -48,7 +49,7 @@ TEMPLATE_TEST_CASE("Tick/1", "[simple traversal benchmark ]", Entity, (EntityFix
   bb->shouldG = bt::Status::SUCCESS;
   bb->shouldH = bt::Status::SUCCESS;
   bb->shouldI = bt::Status::SUCCESS;
-  BENCHMARK("bench tick without priorities ") {
+  BENCHMARK("bench tick without priorities - 6000 nodes ") {
     root.BindTreeBlob(e.blob);
     root.Tick(ctx);
     root.UnbindTreeBlob();
@@ -69,7 +70,7 @@ TEST_CASE("Tick/2", "[simple traversal benchmark - priority ]") {
   bb->shouldPriorityI = 4;
   bb->shouldPriorityH = 3;
   bb->shouldPriorityG = 2;
-  BENCHMARK("bench tick with priorities ") {
+  BENCHMARK("bench tick with priorities - 6000 nodes") {
     root.BindTreeBlob(e.blob);
     root.Tick(ctx);
     root.UnbindTreeBlob();
@@ -87,9 +88,30 @@ TEST_CASE("Tick/3", "[simple traversal benchmark - stateful ]") {
   bb->shouldG = bt::Status::SUCCESS;
   bb->shouldH = bt::Status::SUCCESS;
   bb->shouldI = bt::Status::SUCCESS;
-  BENCHMARK("bench tick without priorities - stateful ") {
+  BENCHMARK("bench tick without priorities - stateful - 6000 nodes ") {
     root.BindTreeBlob(e.blob);
     root.Tick(ctx);
     root.UnbindTreeBlob();
+  };
+}
+
+TEMPLATE_TEST_CASE("Tick/4", "[lots of entities]", Entity, (EntityFixedBlob<602>)) {
+  bt::Tree root;
+  auto bb = std::make_shared<Blackboard>();
+  bt::Context ctx(bb);
+  build(root, 100);
+
+  std::vector<TestType> entities(1000);
+  bb->shouldA = bt::Status::SUCCESS;
+  bb->shouldB = bt::Status::SUCCESS;
+  bb->shouldG = bt::Status::SUCCESS;
+  bb->shouldH = bt::Status::SUCCESS;
+  bb->shouldI = bt::Status::SUCCESS;
+  BENCHMARK("bench lots of entities - 1000 entities x 600 nodes") {
+    for (auto& e : entities) {
+      root.BindTreeBlob(e.blob);
+      root.Tick(ctx);
+      root.UnbindTreeBlob();
+    }
   };
 }

--- a/tests/tick_benchmark.cc
+++ b/tests/tick_benchmark.cc
@@ -51,7 +51,7 @@ TEMPLATE_TEST_CASE("Tick/1", "[simple traversal benchmark ]", Entity, (EntityFix
   bb->shouldI = bt::Status::SUCCESS;
   BENCHMARK("bench tick without priorities - 6000 nodes ") {
     root.BindTreeBlob(e.blob);
-    root.Tick(ctx);
+    ++ctx.seq;root.Tick(ctx);
     root.UnbindTreeBlob();
   };
 }
@@ -72,7 +72,7 @@ TEST_CASE("Tick/2", "[simple traversal benchmark - priority ]") {
   bb->shouldPriorityG = 2;
   BENCHMARK("bench tick with priorities - 6000 nodes") {
     root.BindTreeBlob(e.blob);
-    root.Tick(ctx);
+    ++ctx.seq;root.Tick(ctx);
     root.UnbindTreeBlob();
   };
 }
@@ -90,7 +90,7 @@ TEST_CASE("Tick/3", "[simple traversal benchmark - stateful ]") {
   bb->shouldI = bt::Status::SUCCESS;
   BENCHMARK("bench tick without priorities - stateful - 6000 nodes ") {
     root.BindTreeBlob(e.blob);
-    root.Tick(ctx);
+    ++ctx.seq;root.Tick(ctx);
     root.UnbindTreeBlob();
   };
 }
@@ -110,7 +110,7 @@ TEMPLATE_TEST_CASE("Tick/4", "[lots of entities]", Entity, (EntityFixedBlob<602>
   BENCHMARK("bench lots of entities - 1000 entities x 600 nodes") {
     for (auto& e : entities) {
       root.BindTreeBlob(e.blob);
-      root.Tick(ctx);
+      ++ctx.seq;root.Tick(ctx);
       root.UnbindTreeBlob();
     }
   };

--- a/tests/tick_benchmark.cc
+++ b/tests/tick_benchmark.cc
@@ -95,26 +95,7 @@ TEST_CASE("Tick/3", "[simple traversal benchmark - stateful ]") {
   };
 }
 
-TEMPLATE_TEST_CASE("Tick/4", "[simple traversal benchmark - pool ]", Entity, (EntityFixedBlob<6002>)) {
-  bt::NodePool pool(6002, 320);
-  auto& root = pool.NewTree<bt::Tree>("root");
-  auto bb = std::make_shared<Blackboard>();
-  bt::Context ctx(bb);
-  build(root);
-  TestType e;
-  bb->shouldA = bt::Status::SUCCESS;
-  bb->shouldB = bt::Status::SUCCESS;
-  bb->shouldG = bt::Status::SUCCESS;
-  bb->shouldH = bt::Status::SUCCESS;
-  bb->shouldI = bt::Status::SUCCESS;
-  BENCHMARK("bench tick without priorities - 6000 nodes - pool ") {
-    root.BindTreeBlob(e.blob);
-    root.Tick(ctx);
-    root.UnbindTreeBlob();
-  };
-}
-
-TEMPLATE_TEST_CASE("Tick/5", "[lots of entities]", Entity, (EntityFixedBlob<602>)) {
+TEMPLATE_TEST_CASE("Tick/4", "[lots of entities]", Entity, (EntityFixedBlob<602>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -127,28 +108,6 @@ TEMPLATE_TEST_CASE("Tick/5", "[lots of entities]", Entity, (EntityFixedBlob<602>
   bb->shouldH = bt::Status::SUCCESS;
   bb->shouldI = bt::Status::SUCCESS;
   BENCHMARK("bench lots of entities - 1000 entities x 600 nodes") {
-    for (auto& e : entities) {
-      root.BindTreeBlob(e.blob);
-      root.Tick(ctx);
-      root.UnbindTreeBlob();
-    }
-  };
-}
-
-TEMPLATE_TEST_CASE("Tick/6", "[lots of entities - pool ]", Entity, (EntityFixedBlob<602>)) {
-  bt::NodePool pool(6002, 320);
-  auto& root = pool.NewTree<bt::Tree>("root");
-  auto bb = std::make_shared<Blackboard>();
-  bt::Context ctx(bb);
-  build(root, 100);
-
-  std::vector<TestType> entities(1000);
-  bb->shouldA = bt::Status::SUCCESS;
-  bb->shouldB = bt::Status::SUCCESS;
-  bb->shouldG = bt::Status::SUCCESS;
-  bb->shouldH = bt::Status::SUCCESS;
-  bb->shouldI = bt::Status::SUCCESS;
-  BENCHMARK("bench lots of entities - pool - 1000 entities x 600 nodes") {
     for (auto& e : entities) {
       root.BindTreeBlob(e.blob);
       root.Tick(ctx);

--- a/tests/tick_benchmark.cc
+++ b/tests/tick_benchmark.cc
@@ -95,7 +95,26 @@ TEST_CASE("Tick/3", "[simple traversal benchmark - stateful ]") {
   };
 }
 
-TEMPLATE_TEST_CASE("Tick/4", "[lots of entities]", Entity, (EntityFixedBlob<602>)) {
+TEMPLATE_TEST_CASE("Tick/4", "[simple traversal benchmark - pool ]", Entity, (EntityFixedBlob<6002>)) {
+  bt::NodePool pool(6002, 320);
+  auto& root = pool.NewTree<bt::Tree>("root");
+  auto bb = std::make_shared<Blackboard>();
+  bt::Context ctx(bb);
+  build(root);
+  TestType e;
+  bb->shouldA = bt::Status::SUCCESS;
+  bb->shouldB = bt::Status::SUCCESS;
+  bb->shouldG = bt::Status::SUCCESS;
+  bb->shouldH = bt::Status::SUCCESS;
+  bb->shouldI = bt::Status::SUCCESS;
+  BENCHMARK("bench tick without priorities - 6000 nodes - pool ") {
+    root.BindTreeBlob(e.blob);
+    root.Tick(ctx);
+    root.UnbindTreeBlob();
+  };
+}
+
+TEMPLATE_TEST_CASE("Tick/5", "[lots of entities]", Entity, (EntityFixedBlob<602>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -108,6 +127,28 @@ TEMPLATE_TEST_CASE("Tick/4", "[lots of entities]", Entity, (EntityFixedBlob<602>
   bb->shouldH = bt::Status::SUCCESS;
   bb->shouldI = bt::Status::SUCCESS;
   BENCHMARK("bench lots of entities - 1000 entities x 600 nodes") {
+    for (auto& e : entities) {
+      root.BindTreeBlob(e.blob);
+      root.Tick(ctx);
+      root.UnbindTreeBlob();
+    }
+  };
+}
+
+TEMPLATE_TEST_CASE("Tick/6", "[lots of entities - pool ]", Entity, (EntityFixedBlob<602>)) {
+  bt::NodePool pool(6002, 320);
+  auto& root = pool.NewTree<bt::Tree>("root");
+  auto bb = std::make_shared<Blackboard>();
+  bt::Context ctx(bb);
+  build(root, 100);
+
+  std::vector<TestType> entities(1000);
+  bb->shouldA = bt::Status::SUCCESS;
+  bb->shouldB = bt::Status::SUCCESS;
+  bb->shouldG = bt::Status::SUCCESS;
+  bb->shouldH = bt::Status::SUCCESS;
+  bb->shouldI = bt::Status::SUCCESS;
+  BENCHMARK("bench lots of entities - pool - 1000 entities x 600 nodes") {
     for (auto& e : entities) {
       root.BindTreeBlob(e.blob);
       root.Tick(ctx);

--- a/tests/tick_benchmark.cc
+++ b/tests/tick_benchmark.cc
@@ -92,3 +92,21 @@ TEST_CASE("Tick/3", "[simple traversal benchmark - stateful ]") {
     root.UnbindTreeBlob();
   };
 }
+
+TEST_CASE("Tick/4", "[simple traversal benchmark - fixed blob ]") {
+  bt::Tree root;
+  auto bb = std::make_shared<Blackboard>();
+  bt::Context ctx(bb);
+  build(root);
+  EntityFixedBlob e;
+  bb->shouldA = bt::Status::SUCCESS;
+  bb->shouldB = bt::Status::SUCCESS;
+  bb->shouldG = bt::Status::SUCCESS;
+  bb->shouldH = bt::Status::SUCCESS;
+  bb->shouldI = bt::Status::SUCCESS;
+  BENCHMARK("bench tick without priorities - fixed blob ") {
+    root.BindTreeBlob(e.blob);
+    root.Tick(ctx);
+    root.UnbindTreeBlob();
+  };
+}

--- a/tests/tick_benchmark.cc
+++ b/tests/tick_benchmark.cc
@@ -38,6 +38,26 @@ void buildStateful(bt::Tree& root) {
   root.End();
 }
 
+TEMPLATE_TEST_CASE("Tick/1", "[simple small tree traversal benchmark - 60 nodes ]", Entity,
+                   (EntityFixedBlob<62>)) {
+  bt::Tree root;
+  auto bb = std::make_shared<Blackboard>();
+  bt::Context ctx(bb);
+  build(root, 10);
+  TestType e;
+  bb->shouldA = bt::Status::SUCCESS;
+  bb->shouldB = bt::Status::SUCCESS;
+  bb->shouldG = bt::Status::SUCCESS;
+  bb->shouldH = bt::Status::SUCCESS;
+  bb->shouldI = bt::Status::SUCCESS;
+  BENCHMARK("bench tick without priorities  small tree - 60 nodes ") {
+    root.BindTreeBlob(e.blob);
+    ++ctx.seq;
+    root.Tick(ctx);
+    root.UnbindTreeBlob();
+  };
+}
+
 TEMPLATE_TEST_CASE("Tick/1", "[simple traversal benchmark ]", Entity, (EntityFixedBlob<6002>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
@@ -51,7 +71,8 @@ TEMPLATE_TEST_CASE("Tick/1", "[simple traversal benchmark ]", Entity, (EntityFix
   bb->shouldI = bt::Status::SUCCESS;
   BENCHMARK("bench tick without priorities - 6000 nodes ") {
     root.BindTreeBlob(e.blob);
-    ++ctx.seq;root.Tick(ctx);
+    ++ctx.seq;
+    root.Tick(ctx);
     root.UnbindTreeBlob();
   };
 }
@@ -72,7 +93,8 @@ TEST_CASE("Tick/2", "[simple traversal benchmark - priority ]") {
   bb->shouldPriorityG = 2;
   BENCHMARK("bench tick with priorities - 6000 nodes") {
     root.BindTreeBlob(e.blob);
-    ++ctx.seq;root.Tick(ctx);
+    ++ctx.seq;
+    root.Tick(ctx);
     root.UnbindTreeBlob();
   };
 }
@@ -90,16 +112,17 @@ TEST_CASE("Tick/3", "[simple traversal benchmark - stateful ]") {
   bb->shouldI = bt::Status::SUCCESS;
   BENCHMARK("bench tick without priorities - stateful - 6000 nodes ") {
     root.BindTreeBlob(e.blob);
-    ++ctx.seq;root.Tick(ctx);
+    ++ctx.seq;
+    root.Tick(ctx);
     root.UnbindTreeBlob();
   };
 }
 
-TEMPLATE_TEST_CASE("Tick/4", "[lots of entities]", Entity, (EntityFixedBlob<602>)) {
+TEMPLATE_TEST_CASE("Tick/4", "[lots of entities]", Entity, (EntityFixedBlob<302>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
-  build(root, 100);
+  build(root, 50);
 
   std::vector<TestType> entities(1000);
   bb->shouldA = bt::Status::SUCCESS;
@@ -107,10 +130,11 @@ TEMPLATE_TEST_CASE("Tick/4", "[lots of entities]", Entity, (EntityFixedBlob<602>
   bb->shouldG = bt::Status::SUCCESS;
   bb->shouldH = bt::Status::SUCCESS;
   bb->shouldI = bt::Status::SUCCESS;
-  BENCHMARK("bench lots of entities - 1000 entities x 600 nodes") {
+  BENCHMARK("bench lots of entities - 1000 entities x 300 nodes") {
     for (auto& e : entities) {
       root.BindTreeBlob(e.blob);
-      ++ctx.seq;root.Tick(ctx);
+      ++ctx.seq;
+      root.Tick(ctx);
       root.UnbindTreeBlob();
     }
   };

--- a/tests/timeout_test.cc
+++ b/tests/timeout_test.cc
@@ -1,3 +1,4 @@
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <thread>
 
@@ -6,7 +7,8 @@
 
 using namespace std::chrono_literals;
 
-TEST_CASE("Timeout/1", "[simple timeout success]") {
+TEMPLATE_TEST_CASE("Timeout/1", "[simple timeout success]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::TimeoutNode<>::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -14,12 +16,12 @@ TEST_CASE("Timeout/1", "[simple timeout success]") {
   // clang-format off
     root
     .Timeout(100ms)
-    ._().Action<A>()
+    ._().template Action<A>()
     .End()
     ;
   // clang-format on
 
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
   // Tick#1: A is not started.
   root.Tick(ctx);
@@ -34,7 +36,8 @@ TEST_CASE("Timeout/1", "[simple timeout success]") {
   root.UnbindTreeBlob();
 }
 
-TEST_CASE("Timeout/2", "[simple timeout failure]") {
+TEMPLATE_TEST_CASE("Timeout/2", "[simple timeout failure]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::TimeoutNode<>::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -42,12 +45,12 @@ TEST_CASE("Timeout/2", "[simple timeout failure]") {
   // clang-format off
     root
     .Timeout(100ms)
-    ._().Action<A>()
+    ._().template Action<A>()
     .End()
     ;
   // clang-format on
 
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
   // Tick#1: A is not started.
   root.Tick(ctx);
@@ -62,7 +65,8 @@ TEST_CASE("Timeout/2", "[simple timeout failure]") {
   root.UnbindTreeBlob();
 }
 
-TEST_CASE("Timeout/3", "[simple timeout timedout]") {
+TEMPLATE_TEST_CASE("Timeout/3", "[simple timeout timedout]", Entity,
+                   (EntityFixedBlob<16, sizeof(bt::TimeoutNode<>::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -70,12 +74,12 @@ TEST_CASE("Timeout/3", "[simple timeout timedout]") {
   // clang-format off
     root
     .Timeout(100ms)
-    ._().Action<A>()
+    ._().template Action<A>()
     .End()
     ;
   // clang-format on
 
-  Entity e;
+  TestType e;
   root.BindTreeBlob(e.blob);
   // Tick#1: A is not started.
   root.Tick(ctx);

--- a/tests/timeout_test.cc
+++ b/tests/timeout_test.cc
@@ -16,7 +16,7 @@ TEMPLATE_TEST_CASE("Timeout/1", "[simple timeout success]", Entity,
   // clang-format off
     root
     .Timeout(100ms)
-    ._().template Action<A>()
+    ._().Action<A>()
     .End()
     ;
   // clang-format on
@@ -45,7 +45,7 @@ TEMPLATE_TEST_CASE("Timeout/2", "[simple timeout failure]", Entity,
   // clang-format off
     root
     .Timeout(100ms)
-    ._().template Action<A>()
+    ._().Action<A>()
     .End()
     ;
   // clang-format on
@@ -74,7 +74,7 @@ TEMPLATE_TEST_CASE("Timeout/3", "[simple timeout timedout]", Entity,
   // clang-format off
     root
     .Timeout(100ms)
-    ._().template Action<A>()
+    ._().Action<A>()
     .End()
     ;
   // clang-format on

--- a/tests/timeout_test.cc
+++ b/tests/timeout_test.cc
@@ -24,13 +24,13 @@ TEMPLATE_TEST_CASE("Timeout/1", "[simple timeout success]", Entity,
   TestType e;
   root.BindTreeBlob(e.blob);
   // Tick#1: A is not started.
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: Makes A success.
   bb->shouldA = bt::Status::SUCCESS;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
   root.UnbindTreeBlob();
@@ -53,13 +53,13 @@ TEMPLATE_TEST_CASE("Timeout/2", "[simple timeout failure]", Entity,
   TestType e;
   root.BindTreeBlob(e.blob);
   // Tick#1: A is not started.
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: Makes A failure.
   bb->shouldA = bt::Status::FAILURE;
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
   root.UnbindTreeBlob();
@@ -82,13 +82,13 @@ TEMPLATE_TEST_CASE("Timeout/3", "[simple timeout timedout]", Entity,
   TestType e;
   root.BindTreeBlob(e.blob);
   // Tick#1: A is not started.
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: should timeout
   std::this_thread::sleep_for(110ms);
-  root.Tick(ctx);
+  ++ctx.seq;root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
   root.UnbindTreeBlob();

--- a/tests/types.h
+++ b/tests/types.h
@@ -44,8 +44,9 @@ struct Entity {
   bt::TreeBlob blob;
 };
 
+template <std::size_t N, std::size_t M>
 struct EntityFixedBlob {
-  bt::FixedTreeBlob<7100, 48> blob;
+  bt::FixedTreeBlob<N, M> blob;
 };
 
 class A : public bt::Action {

--- a/tests/types.h
+++ b/tests/types.h
@@ -44,6 +44,10 @@ struct Entity {
   bt::TreeBlob blob;
 };
 
+struct EntityFixedBlob {
+  bt::FixedTreeBlob<7100, 48> blob;
+};
+
 class A : public bt::Action {
  public:
   void OnEnter(const bt::Context& ctx) override {

--- a/tests/types.h
+++ b/tests/types.h
@@ -41,7 +41,7 @@ struct Blackboard {
 };
 
 struct Entity {
-  bt::TreeBlob blob;
+  bt::DynamicTreeBlob blob;
 };
 
 template <std::size_t N, std::size_t M>

--- a/tests/types.h
+++ b/tests/types.h
@@ -44,12 +44,12 @@ struct Entity {
   bt::DynamicTreeBlob blob;
 };
 
-template <std::size_t N, std::size_t M>
+template <std::size_t N, std::size_t M = sizeof(bt::NodeBlob)>
 struct EntityFixedBlob {
   bt::FixedTreeBlob<N, M> blob;
 };
 
-class A : public bt::Action {
+class A : public bt::ActionNode {
  public:
   void OnEnter(const bt::Context& ctx) override {
     auto bb = std::any_cast<std::shared_ptr<Blackboard>>(ctx.data);
@@ -66,7 +66,7 @@ class A : public bt::Action {
   }
 };
 
-class B : public bt::Action {
+class B : public bt::ActionNode {
  public:
   bt::Status Update(const bt::Context& ctx) override {
     auto bb = std::any_cast<std::shared_ptr<Blackboard>>(ctx.data);
@@ -75,7 +75,7 @@ class B : public bt::Action {
   }
 };
 
-class C : public bt::Condition {
+class C : public bt::ConditionNode {
  public:
   bool Check(const bt::Context& ctx) override {
     auto bb = std::any_cast<std::shared_ptr<Blackboard>>(ctx.data);
@@ -83,7 +83,7 @@ class C : public bt::Condition {
   }
 };
 
-class D : public bt::Condition {
+class D : public bt::ConditionNode {
  public:
   bool Check(const bt::Context& ctx) override {
     auto bb = std::any_cast<std::shared_ptr<Blackboard>>(ctx.data);
@@ -91,7 +91,7 @@ class D : public bt::Condition {
   }
 };
 
-class E : public bt::Action {
+class E : public bt::ActionNode {
  public:
   bt::Status Update(const bt::Context& ctx) override {
     auto bb = std::any_cast<std::shared_ptr<Blackboard>>(ctx.data);
@@ -100,7 +100,7 @@ class E : public bt::Action {
   }
 };
 
-class F : public bt::Condition {
+class F : public bt::ConditionNode {
  public:
   bool Check(const bt::Context& ctx) override {
     auto bb = std::any_cast<std::shared_ptr<Blackboard>>(ctx.data);
@@ -108,7 +108,7 @@ class F : public bt::Condition {
   }
 };
 
-class G : public bt::Action {
+class G : public bt::ActionNode {
  public:
   bt::Status Update(const bt::Context& ctx) override {
     auto bb = std::any_cast<std::shared_ptr<Blackboard>>(ctx.data);
@@ -121,7 +121,7 @@ class G : public bt::Action {
   }
 };
 
-class H : public bt::Action {
+class H : public bt::ActionNode {
  public:
   bt::Status Update(const bt::Context& ctx) override {
     auto bb = std::any_cast<std::shared_ptr<Blackboard>>(ctx.data);
@@ -134,7 +134,7 @@ class H : public bt::Action {
   }
 };
 
-class I : public bt::Action {
+class I : public bt::ActionNode {
  public:
   bt::Status Update(const bt::Context& ctx) override {
     auto bb = std::any_cast<std::shared_ptr<Blackboard>>(ctx.data);


### PR DESCRIPTION
~~Optional NodePool~~
- [x] Split TreeBlob to FixedTreeBlob and Dynamic TreeBlob.
   - [x] FixedTreeBlob tests
   - [x] FixedTreeBlob vs DynamicTreeBlob benchmark on lots of entities
- [x] A stateful node must export a type alias named `Blob`
- [x] size info apis: `Size()`, `TreeSize()`, `NumNodes()` , `MaxSizeNode()`, `MaxSizeNodeBlob()`
   - [x] tests

Plan:



```cpp
// Requires size info, can get from root.maxSizeNodeBlob() and root.NumNodes().
// Memory will be continuous on the entity.
FixedTreeBlob<8, 64> blob;

// No need for size info template parameters, but memory aren't continuous.
DynamicTreeBlob blob;
```
