### PR TITLE
0.4.0: separate cpp file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 20)
 
 option(BT_TEST "Enables testing" OFF)
 
-add_library(bt INTERFACE)
+add_library(bt SHARED bt.cc)
 set_target_properties(bt PROPERTIES PUBLIC_HEADER "bt.h")
 
 if(BT_TEST)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bt.h
+# bt.cc
 
 ![](https://github.com/hit9/bt/actions/workflows/tests.yml/badge.svg)
 ![](https://img.shields.io/badge/license-BSD3-brightgreen)
@@ -15,7 +15,7 @@ Requires at least C++20.
 
 ## Installation
 
-Just copy the header file `bt.h` and include it.
+Copy away `bt.h` and `bt.cc`.
 
 ## Features
 
@@ -592,7 +592,7 @@ Reference: <span id="ref"></span>
 
 * **Visualization**  <span id="visualization"></span> <a href="#ref">[↑]</a>
 
-  There's a simple real time behavior tree visualization function implemented in `bt.h`.
+  There's a simple real time behavior tree visualization function implemented in `bt.cc`.
 
   It simply displays the tree structure and execution status on the console.
   The nodes colored in green are those currently executing and are synchronized with the latest tick cycles.
@@ -635,7 +635,7 @@ Reference: <span id="ref"></span>
 
 * **Ticker Loop**   <span id="ticker-loop"></span> <a href="#ref">[↑]</a>
 
-  There's a simple builtin ticker loop implemented in `bt.h`, to use it:
+  There's a simple builtin ticker loop implemented in `bt.cc`, to use it:
 
   ```cpp
   root.TickForever(ctx, 100ms);
@@ -678,7 +678,7 @@ Reference: <span id="ref"></span>
   It's a common case to emit and receive signals in a behavior tree.
   But signal (or event) handling is a complex stuff, I don't want to couple with it in this small library.
 
-  General ideas to introduce signal handling into bt.h is:
+  General ideas to introduce signal handling into bt.cc is:
 
   1. Creates a custom decorator node, supposed named `OnSignalNode`.
   2. Creates a custom builder class, and add a method named `OnSignal`.
@@ -686,7 +686,7 @@ Reference: <span id="ref"></span>
   4. The data passing along with the fired signal, can be placed onto the blackboard temporary.
   5. You can move the OnSignal node as high as possible to make the entire behavior tree more event-driven.
 
-  Here's an example in detail to combine my tiny signal library [blinker.h](https://github.com/hit9/blinker.h) with bt.h,
+  Here's an example in detail to combine my tiny signal library [blinker.h](https://github.com/hit9/blinker.h) with bt.cc,
   please checkout the code example in folder [example/onsignal](example/onsignal).
 
   ```cpp

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,4 +1,4 @@
-# bt.h
+# bt.cc
 
 ![](https://github.com/hit9/bt/actions/workflows/tests.yml/badge.svg)
 ![](https://img.shields.io/badge/license-BSD3-brightgreen)
@@ -13,7 +13,7 @@
 
 ## 安装
 
-只需要拷贝走头文件 `bt.h`
+只需要拷贝走 `bt.h` 和 `bt.cc`
 
 ## 特点
 
@@ -237,7 +237,7 @@ while(...) {
     // 任何一个有实体状态的节点都应该定义一个类型成员, 叫做 Blob
     using Blob = ANodeBlob;
     // 需要重载这个方法, 返回一个指向基础类 NodeBlob 类型的指针
-    // getNodeBlob 是 bt.h 提供的方法, 定义在 `Node` 中
+    // getNodeBlob 是库提供的方法, 定义在 `Node` 中
     NodeBlob* GetNodeBlob() const override { return getNodeBlob<ANodeBlob>(); }
 
     // 在这个类的方法中，可以用 getNodeBlob<ANodeBlob>() 来获取数据块的指针, 来查询和修改实体相关的数据。
@@ -580,7 +580,7 @@ while(...) {
 
 * **可视化**  <span id="visualization"></span> <a href="#ref">[↑]</a>
 
-  `bt.h` 实现了一个简单的实时把行为树运行状态可视化展示的函数，绿色的节点表示正在被 tick 的节点。
+  `bt.cc` 实现了一个简单的实时把行为树运行状态可视化展示的函数，绿色的节点表示正在被 tick 的节点。
 
   用法示例：
 
@@ -618,7 +618,7 @@ while(...) {
 
 * **Tick 循环**   <span id="ticker-loop"></span> <a href="#ref">[↑]</a>
 
-  `bt.h` 中内置了一个简单额 tick 主循环：
+  `bt.cc` 中内置了一个简单额 tick 主循环：
 
   ```cpp
   root.TickForever(ctx, 100ms);
@@ -659,9 +659,9 @@ while(...) {
 
 * **信号和事件** <span id="signals"></span> <a href="#ref">[↑]</a>
 
-  在行为树中释放和处理信号是常见的情况, 但是信号和事件的处理是一个复杂的事情, 我并不想让其和 bt.h 这个很小的库耦合起来.
+  在行为树中释放和处理信号是常见的情况, 但是信号和事件的处理是一个复杂的事情, 我并不想让其和 bt.cc 这个很小的库耦合起来.
 
-  一般来说, 要想把信号处理的带入 bt.h 中, 思路如下:
+  一般来说, 要想把信号处理的带入 bt.cc 中, 思路如下:
 
   1. 创建一个自定义的装饰节点, 比如说叫做 `OnSignalNode`.
   2. 创建一个自定义的 Builder 类, 添加一个方法叫做 `OnSignal`.

--- a/bt.cc
+++ b/bt.cc
@@ -5,7 +5,6 @@
 #include "bt.h"
 
 #include <algorithm>  // for max
-#include <iostream>   // for cout, flush
 #include <random>     // for mt19937
 #include <thread>     // for this_thread::sleep_for
 
@@ -15,7 +14,7 @@ namespace bt {
 /// TreeBlob
 /////////////////
 
-std::pair<void*, bool> ITreeBlob::make(const NodeId id, size_t size, const std::size_t cap) {
+std::pair<void*, bool> ITreeBlob::make(const NodeId id, const size_t size, const std::size_t cap) {
   if (cap) reserve(cap);
   std::size_t idx = id - 1;
   if (exist(idx)) return {get(idx), false};
@@ -492,11 +491,11 @@ Status RetryNode::Update(const Context& ctx) {
 void RootNode::Visualize(ull seq) {
   // CSI[2J clears screen.
   // CSI[H moves the cursor to top-left corner
-  std::cout << "\x1B[2J\x1B[H" << std::flush;
+  printf("\x1B[2J\x1B[H");
   // Make a string.
   std::string s;
   makeVisualizeString(s, 0, seq);
-  std::cout << s << std::flush;
+  printf("%s", s.c_str());
 }
 
 void RootNode::TickForever(Context& ctx, std::chrono::nanoseconds interval, bool visualize,

--- a/bt.cc
+++ b/bt.cc
@@ -1,0 +1,480 @@
+#include "bt.h"
+
+#include <iostream>  // for cout, flush
+
+namespace bt {
+
+/////////////////
+/// TreeBlob
+/////////////////
+
+std::pair<void*, bool> ITreeBlob::make(const NodeId id, size_t size, const std::size_t cap) {
+  if (cap) reserve(cap);
+  std::size_t idx = id - 1;
+  if (exist(idx)) return {get(idx), false};
+  return {allocate(idx, size), true};
+}
+
+void* DynamicTreeBlob::allocate(const std::size_t idx, const std::size_t size) {
+  if (m.size() <= idx) {
+    m.resize(idx + 1);
+    e.resize(idx + 1, false);
+  }
+  auto p = std::make_unique_for_overwrite<unsigned char[]>(size);
+  auto rp = p.get();
+  std::fill_n(rp, size, 0);
+  m[idx] = std::move(p);
+  e[idx] = true;
+  return rp;
+}
+
+void DynamicTreeBlob::reserve(const std::size_t cap) {
+  if (m.capacity() < cap) {
+    m.reserve(cap);
+    e.reserve(cap);
+  }
+}
+
+////////////////////////////
+/// Node
+////////////////////////////
+
+// Returns char representation of given status.
+static const char statusRepr(Status s) {
+  switch (s) {
+    case Status::UNDEFINED:
+      return 'U';
+    case Status::RUNNING:
+      return 'R';
+    case Status::SUCCESS:
+      return 'S';
+    case Status::FAILURE:
+      return 'F';
+  }
+  return 'U';
+}
+
+void Node::makeVisualizeString(std::string& s, int depth, ull seq) {
+  auto b = GetNodeBlob();
+  if (depth > 0) s += " |";
+  for (int i = 1; i < depth; i++) s += "---|";
+  if (depth > 0) s += "- ";
+  if (b->lastSeq == seq) s += "\033[32m";  // color if catches up with seq.
+  s += Name();
+  s.push_back('(');
+  s.push_back(statusRepr(b->lastStatus));
+  s.push_back(')');
+  if (b->lastSeq == seq) s += "\033[0m";
+}
+
+unsigned int Node::GetPriorityCurrentTick(const Context& ctx) {
+  if (ctx.seq != priorityCurrentTickSeq) priorityCurrentTick = 0;
+  // try cache in this tick firstly.
+  if (!priorityCurrentTick) {
+    priorityCurrentTick = Priority(ctx);
+    priorityCurrentTickSeq = ctx.seq;
+  }
+  return priorityCurrentTick;
+}
+
+void Node::Traverse(TraversalCallback& pre, TraversalCallback& post, Ptr<Node>& ptr) {
+  pre(*this, ptr);
+  post(*this, ptr);
+}
+
+Status Node::Tick(const Context& ctx) {
+  auto b = GetNodeBlob();
+  // First run of current round.
+  if (!b->running) OnEnter(ctx);
+  b->running = true;
+
+  auto status = Update(ctx);
+  b->lastStatus = status;
+  b->lastSeq = ctx.seq;
+
+  // Last run of current round.
+  if (status == Status::FAILURE || status == Status::SUCCESS) {
+    OnTerminate(ctx, status);
+    b->running = false;  // reset
+  }
+  return status;
+}
+
+////////////////////////////////////////////////
+/// Node > InternalNode > SingleNode
+////////////////////////////////////////////////
+
+void SingleNode::makeVisualizeString(std::string& s, int depth, ull seq) {
+  Node::makeVisualizeString(s, depth, seq);
+  if (child != nullptr) {
+    s.push_back('\n');
+    child->makeVisualizeString(s, depth + 1, seq);
+  }
+}
+
+void SingleNode::Traverse(TraversalCallback& pre, TraversalCallback& post, Ptr<Node>& ptr) {
+  pre(*this, ptr);
+  if (child != nullptr) child->Traverse(pre, post, child);
+  post(*this, ptr);
+}
+
+////////////////////////////////////////////////
+/// Node > InternalNode > CompositeNode
+////////////////////////////////////////////////
+
+void CompositeNode::makeVisualizeString(std::string& s, int depth, ull seq) {
+  Node::makeVisualizeString(s, depth, seq);
+  for (auto& child : children) {
+    if (child != nullptr) {
+      s.push_back('\n');
+      child->makeVisualizeString(s, depth + 1, seq);
+    }
+  }
+}
+
+void CompositeNode::Traverse(TraversalCallback& pre, TraversalCallback& post, Ptr<Node>& ptr) {
+  pre(*this, ptr);
+  for (auto& child : children)
+    if (child != nullptr) child->Traverse(pre, post, child);
+  post(*this, ptr);
+}
+
+unsigned int CompositeNode::Priority(const Context& ctx) const {
+  unsigned int ans = 0;
+  for (int i = 0; i < children.size(); i++)
+    if (considerable(i)) ans = std::max(ans, children[i]->GetPriorityCurrentTick(ctx));
+  return ans;
+}
+
+//////////////////////////////////////////////////////////////
+/// Node > InternalNode > CompositeNode > _Internal Impls
+///////////////////////////////////////////////////////////////
+
+void _InternalStatefulCompositeNode::OnTerminate(const Context& ctx, Status status) {
+  auto& t = getNodeBlob<Blob>()->st;
+  std::fill(t.begin(), t.end(), false);
+}
+
+void _InternalStatefulCompositeNode::OnBlobAllocated(NodeBlob* blob) const {
+  auto ptr = static_cast<Blob*>(blob);
+  ptr->st.resize(children.size(), false);
+}
+
+_MixedQueueHelper::_MixedQueueHelper(Cmp cmp, const std::size_t n) {
+  // reserve capacity for q1.
+  q1Container.reserve(n);
+  q1 = &q1Container;
+  // reserve capacity for q2.
+  decltype(q2) _q2(cmp);
+  q2.swap(_q2);
+  q2.reserve(n);
+}
+
+int _MixedQueueHelper::pop() {
+  if (use1) return (*q1)[q1Front++];
+  int v = q2.top();
+  q2.pop();
+  return v;
+}
+
+void _MixedQueueHelper::push(int v) {
+  if (use1) {
+    if (q1 != &q1Container) throw std::runtime_error("bt: cant push on outside q1 container");
+    return q1->push_back(v);
+  }
+  q2.push(v);
+}
+
+bool _MixedQueueHelper::empty() const {
+  if (use1) return q1Front == q1->size();
+  return q2.empty();
+}
+
+void _MixedQueueHelper::clear() {
+  if (use1) {
+    if (q1 != &q1Container) throw std::runtime_error("bt: cant clear on outside q1 container");
+    q1->resize(0);
+    q1Front = 0;
+    return;
+  }
+  q2.clear();
+}
+
+void _MixedQueueHelper::setQ1Container(std::vector<int>* c) {
+  q1 = c;
+  q1Front = 0;
+}
+
+void _InternalPriorityCompositeNode::refresh(const Context& ctx) {
+  areAllEqual = true;
+  // v is the first valid priority value.
+  unsigned int v = 0;
+
+  for (int i = 0; i < children.size(); i++) {
+    if (!considerable(i)) continue;
+    p[i] = children[i]->GetPriorityCurrentTick(ctx);
+    if (!v) v = p[i];
+    if (v != p[i]) areAllEqual = false;
+  }
+}
+
+void _InternalPriorityCompositeNode::enqueue() {
+  // if all priorities are equal, use q1 O(N)
+  // otherwise, use q2 O(n*logn)
+  q.setflag(areAllEqual);
+
+  // We have to consider all children, and all priorities are equal,
+  // then, we should just use a pre-exist vector to avoid a O(n) copy to q1.
+  if ((!isParatialConsidered()) && areAllEqual) {
+    q.setQ1Container(&simpleQ1Container);
+    return;  // no need to perform enqueue
+  }
+
+  q.resetQ1Container();
+
+  // Clear and enqueue.
+  q.clear();
+  for (int i = 0; i < children.size(); i++)
+    if (considerable(i)) q.push(i);
+}
+
+void _InternalPriorityCompositeNode::internalOnBuild() {
+  CompositeNode::internalOnBuild();
+  // pre-allocate capacity for p.
+  p.resize(children.size());
+  // initialize simpleQ1Container;
+  for (int i = 0; i < children.size(); i++) simpleQ1Container.push_back(i);
+  // Compare priorities between children, where a and b are indexes.
+  // priority from large to smaller, so use `less`: pa < pb
+  // order: from small to larger, so use `greater`: a > b
+  auto cmp = [&](const int a, const int b) { return p[a] < p[b] || a > b; };
+  q = _MixedQueueHelper(cmp, children.size());
+}
+
+Status _InternalPriorityCompositeNode::Update(const Context& ctx) {
+  refresh(ctx);
+  enqueue();
+  // propagates ticks
+  return update(ctx);
+}
+
+//////////////////////////////////////////////////////////////
+/// Node > InternalNode > CompositeNode > SequenceNode
+///////////////////////////////////////////////////////////////
+
+Status _InternalSequenceNodeBase::update(const Context& ctx) {
+  // propagates ticks, one by one sequentially.
+  while (!q.empty()) {
+    auto i = q.pop();
+    auto status = children[i]->Tick(ctx);
+    if (status == Status::RUNNING) return Status::RUNNING;
+    // F if any child F.
+    if (status == Status::FAILURE) {
+      onChildFailure(i);
+      return Status::FAILURE;
+    }
+    // S
+    onChildSuccess(i);
+  }
+  // S if all children S.
+  return Status::SUCCESS;
+}
+
+//////////////////////////////////////////////////////////////
+/// Node > InternalNode > CompositeNode > SelectorNode
+///////////////////////////////////////////////////////////////
+
+Status _InternalSelectorNodeBase::update(const Context& ctx) {
+  // select a success children.
+  while (!q.empty()) {
+    auto i = q.pop();
+    auto status = children[i]->Tick(ctx);
+    if (status == Status::RUNNING) return Status::RUNNING;
+    // S if any child S.
+    if (status == Status::SUCCESS) {
+      onChildSuccess(i);
+      return Status::SUCCESS;
+    }
+    // F
+    onChildFailure(i);
+  }
+  // F if all children F.
+  return Status::FAILURE;
+}
+
+//////////////////////////////////////////////////////////////
+/// Node > InternalNode > CompositeNode > RandomSelectorNode
+///////////////////////////////////////////////////////////////
+
+static std::mt19937 rng(std::random_device{}());  // seed random
+
+Status _InternalRandomSelectorNodeBase::update(const Context& ctx) {
+  // Sum of weights/priorities.
+  unsigned int total = 0;
+  for (int i = 0; i < children.size(); i++)
+    if (considerable(i)) total += p[i];
+
+  // random select one, in range [1, total]
+  std::uniform_int_distribution<unsigned int> distribution(1, total);
+
+  auto select = [&]() -> int {
+    unsigned int v = distribution(rng);  // gen random unsigned int between [0, sum]
+    unsigned int s = 0;                  // sum of iterated children.
+    for (int i = 0; i < children.size(); i++) {
+      if (!considerable(i)) continue;
+      s += p[i];
+      if (v <= s) return i;
+    }
+    return 0;  // won't reach here.
+  };
+
+  // While still have children considerable.
+  // total reaches 0 only if no children left,
+  // notes that Priority() always returns a positive value.
+  while (total) {
+    int i = select();
+    auto status = children[i]->Tick(ctx);
+    if (status == Status::RUNNING) return Status::RUNNING;
+    // S if any child S.
+    if (status == Status::SUCCESS) {
+      onChildSuccess(i);
+      return Status::SUCCESS;
+    }
+    // Failure, it shouldn't be considered any more in this tick.
+    onChildFailure(i);
+    // remove its weight from total, won't be consider again.
+    total -= p[i];
+    // updates the upper bound of distribution.
+    distribution.param(std::uniform_int_distribution<unsigned int>::param_type(1, total));
+  }
+  // F if all children F.
+  return Status::FAILURE;
+}
+
+Status _InternalRandomSelectorNodeBase::Update(const Context& ctx) {
+  refresh(ctx);
+  return update(ctx);
+}
+
+//////////////////////////////////////////////////////////////
+/// Node > InternalNode > CompositeNode > ParallelNode
+///////////////////////////////////////////////////////////////
+
+Status _InternalParallelNodeBase::update(const Context& ctx) {
+  // Propagates tick to all considerable children.
+  int cntFailure = 0, cntSuccess = 0, total = 0;
+  while (!q.empty()) {
+    auto i = q.pop();
+    auto status = children[i]->Tick(ctx);
+    total++;
+    if (status == Status::FAILURE) {
+      cntFailure++;
+      onChildFailure(i);
+    }
+    if (status == Status::SUCCESS) {
+      cntSuccess++;
+      onChildSuccess(i);
+    }
+  }
+
+  // S if all children S.
+  if (cntSuccess == total) return Status::SUCCESS;
+  // F if any child F.
+  if (cntFailure > 0) return Status::FAILURE;
+  return Status::RUNNING;
+}
+
+//////////////////////////////////////////////////////////////
+/// Node > InternalNode > CompositeNode > Decorator
+///////////////////////////////////////////////////////////////
+
+Status InvertNode::Update(const Context& ctx) {
+  auto status = child->Tick(ctx);
+  switch (status) {
+    case Status::RUNNING:
+      return Status::RUNNING;
+    case Status::FAILURE:
+      return Status::SUCCESS;
+    default:
+      return Status::FAILURE;
+  }
+}
+
+void ConditionalRunNode::Traverse(TraversalCallback& pre, TraversalCallback& post, Ptr<Node>& ptr) {
+  pre(*this, ptr);
+  if (condition != nullptr) condition->Traverse(pre, post, condition);
+  if (child != nullptr) child->Traverse(pre, post, child);
+  post(*this, ptr);
+}
+
+Status ConditionalRunNode::Update(const Context& ctx) {
+  if (condition->Tick(ctx) == Status::SUCCESS) return child->Tick(ctx);
+  return Status::FAILURE;
+}
+
+Status RepeatNode::Update(const Context& ctx) {
+  if (n == 0) return Status::SUCCESS;
+  auto status = child->Tick(ctx);
+  if (status == Status::RUNNING) return Status::RUNNING;
+  if (status == Status::FAILURE) return Status::FAILURE;
+  // Count success until n times, -1 will never stop.
+  if (++(getNodeBlob<Blob>()->cnt) == n) return Status::SUCCESS;
+  // Otherwise, it's still running.
+  return Status::RUNNING;
+}
+
+//////////////////////////////////////////////////////////////
+/// Node > SingleNode > RootNode
+///////////////////////////////////////////////////////////////
+
+void RootNode::Visualize(ull seq) {
+  // CSI[2J clears screen.
+  // CSI[H moves the cursor to top-left corner
+  std::cout << "\x1B[2J\x1B[H" << std::flush;
+  // Make a string.
+  std::string s;
+  makeVisualizeString(s, 0, seq);
+  std::cout << s << std::flush;
+}
+
+//////////////////////////////////////////////////////////////
+/// Tree Builder
+///////////////////////////////////////////////////////////////
+
+void _InternalBuilderBase::maintainNodeBindInfo(Node& node, RootNode* root) {
+  node.root = root;
+  root->n++;
+  node.id = ++nextNodeId;
+}
+void _InternalBuilderBase::maintainSizeInfoOnRootBind(RootNode* root, std::size_t rootNodeSize,
+                                                      std::size_t blobSize) {
+  root->size = rootNodeSize;
+  root->treeSize += rootNodeSize;
+  root->maxSizeNode = rootNodeSize;
+  root->maxSizeNodeBlob = blobSize;
+}
+
+void _InternalBuilderBase::maintainSizeInfoOnSubtreeAttach(RootNode& subtree, RootNode* root) {
+  root->treeSize += subtree.treeSize;
+  root->maxSizeNode = std::max(root->maxSizeNode, subtree.maxSizeNode);
+  root->maxSizeNodeBlob = std::max(root->maxSizeNodeBlob, subtree.maxSizeNodeBlob);
+}
+
+void _InternalBuilderBase::onRootAttach(RootNode* root, std::size_t size, std::size_t blobSize) {
+  maintainNodeBindInfo(*root, root);
+  maintainSizeInfoOnRootBind(root, size, blobSize);
+}
+
+void _InternalBuilderBase::onSubtreeAttach(RootNode& subtree, RootNode* root) {
+  // Resets root in sub tree recursively.
+  TraversalCallback pre = [&](Node& node, Ptr<Node>& ptr) { maintainNodeBindInfo(node, root); };
+  subtree.Traverse(pre, NullTraversalCallback, NullNodePtr);
+  maintainSizeInfoOnSubtreeAttach(subtree, root);
+}
+
+void _InternalBuilderBase::onNodeBuild(Node* node) {
+  node->internalOnBuild();
+  node->OnBuild();
+}
+
+}  // namespace bt

--- a/bt.cc
+++ b/bt.cc
@@ -5,9 +5,9 @@
 #include "bt.h"
 
 #include <algorithm>  // for max
+#include <cstdio>     // for printf
 #include <random>     // for mt19937
 #include <thread>     // for this_thread::sleep_for
-#include <cstdio>     // for printf
 
 namespace bt {
 

--- a/bt.cc
+++ b/bt.cc
@@ -1,8 +1,13 @@
+// Copyright (c) 2024 Chao Wang <hit9@icloud.com>.
+// License: BSD, Version: 0.4.0.  https://github.com/hit9/bt.cc
+// A lightweight behavior tree library that separates data and behavior.
+
 #include "bt.h"
 
-#include <iostream>  // for cout, flush
-#include <random>    // for mt19937
-#include <thread>    // for this_thread::sleep_for
+#include <algorithm>  // for max
+#include <iostream>   // for cout, flush
+#include <random>     // for mt19937
+#include <thread>     // for this_thread::sleep_for
 
 namespace bt {
 
@@ -310,7 +315,8 @@ Status _InternalSelectorNodeBase::update(const Context& ctx) {
 
 static std::mt19937 rng(std::random_device{}());  // seed random
 
-Status _InternalRandomSelectorNodeBase::update(const Context& ctx) {
+Status _InternalRandomSelectorNodeBase::Update(const Context& ctx) {
+  refresh(ctx);
   // Sum of weights/priorities.
   unsigned int total = 0;
   for (int i = 0; i < children.size(); i++)
@@ -351,11 +357,6 @@ Status _InternalRandomSelectorNodeBase::update(const Context& ctx) {
   }
   // F if all children F.
   return Status::FAILURE;
-}
-
-Status _InternalRandomSelectorNodeBase::Update(const Context& ctx) {
-  refresh(ctx);
-  return update(ctx);
 }
 
 //////////////////////////////////////////////////////////////

--- a/bt.cc
+++ b/bt.cc
@@ -7,6 +7,7 @@
 #include <algorithm>  // for max
 #include <random>     // for mt19937
 #include <thread>     // for this_thread::sleep_for
+#include <cstdio>     // for printf
 
 namespace bt {
 

--- a/bt.h
+++ b/bt.h
@@ -834,19 +834,16 @@ class Builder : public _InternalBuilderBase {
     root = &r;
     onRootAttach(root, sizeof(D), sizeof(typename D::Blob));
   }
-
   // Creates a leaf node.
   auto& attachLeafNode(Ptr<LeafNode> p) {
     _InternalBuilderBase::attachLeafNode(std::move(p));
     return *static_cast<D*>(this);
   }
-
   // Creates an internal node with optional children.
   auto& attachInternalNode(Ptr<InternalNode> p) {
     _InternalBuilderBase::attachInternalNode(std::move(p));
     return *static_cast<D*>(this);
   }
-
   // make a new node onto this tree, returns the unique_ptr.
   // Any node creation should use this function.
   template <TNode T, typename... Args>
@@ -864,7 +861,6 @@ class Builder : public _InternalBuilderBase {
   void End() {
     while (stack.size()) pop();  // clears the stack
   }
-
   // Increases indent level to append node.
   auto& _() {
     level++;
@@ -888,7 +884,6 @@ class Builder : public _InternalBuilderBase {
     else  // InternalNode.
       return attachInternalNode(make<T>(false, std::forward<Args>(args)...));
   }
-
   // Attach a node through move, rarely used.
   template <TNode T>
   auto& M(T&& inst) {
@@ -904,33 +899,26 @@ class Builder : public _InternalBuilderBase {
   // A SequenceNode executes its children one by one sequentially,
   // it succeeds only if all children succeed.
   auto& Sequence() { return C<SequenceNode>("Sequence"); }
-
   // A StatefulSequenceNode behaves like a sequence node, executes its children sequentially, succeeds if
   // all children succeed, fails if any child fails. What's the difference is, a StatefulSequenceNode skips
   // the succeeded children instead of always starting from the first child.
   auto& StatefulSequence() { return C<StatefulSequenceNode>("Sequence*"); }
-
   // A SelectorNode succeeds if any child succeeds, fails only if all children fail.
   auto& Selector() { return C<SelectorNode>("Selector"); }
-
   // A StatefulSelectorNode behaves like a selector node, executes its children sequentially, succeeds if
   // any child succeeds, fails if all child fail. What's the difference is, a StatefulSelectorNode skips the
   // failure children instead of always starting from the first child.
   auto& StatefulSelector() { return C<StatefulSelectorNode>("Selector*"); }
-
   // A ParallelNode executes its children parallelly.
   // It succeeds if all children succeed, and fails if any child fails.
   auto& Parallel() { return C<ParallelNode>("Parallel"); }
-
   // A StatefulParallelNode behaves like a parallel node, executes its children parallelly, succeeds if all
   // succeed, fails if all child fail. What's the difference is, a StatefulParallelNode will skip the
   // "already success" children instead of executing every child all the time.
   auto& StatefulParallel() { return C<StatefulParallelNode>("Parallel*"); }
-
   // A RandomSelectorNode determines a child via weighted random selection.
   // It continues to randomly select a child, propagating tick, until some child succeeds.
   auto& RandomSelector() { return C<RandomSelectorNode>("RandomSelector"); }
-
   // A StatefulRandomSelector behaves like a random selector node, the difference is, a
   // StatefulRandomSelector will skip already failed children during a round.
   auto& StatefulRandomSelector() { return C<StatefulRandomSelectorNode>("RandomSelector*"); }
@@ -947,7 +935,6 @@ class Builder : public _InternalBuilderBase {
   auto& Action(Args&&... args) {
     return C<Impl>(std::forward<Args>(args)...);
   }
-
   // Creates a ConditionNode from a lambda function.
   // Code example::
   //   root
@@ -956,7 +943,6 @@ class Builder : public _InternalBuilderBase {
   //   ._().Action<A>()
   //   .End();
   auto& Condition(ConditionNode::Checker checker) { return C<ConditionNode>(checker); }
-
   // Creates a ConditionNode by providing implemented Condition class.
   // Code example::
   //   root
@@ -980,7 +966,6 @@ class Builder : public _InternalBuilderBase {
   //   ._().Condition<A>()
   //   .End();
   auto& Invert() { return C<InvertNode>("Invert"); }
-
   // Alias to Invert, just named 'Not'.
   // Code exapmle::
   //   root
@@ -988,7 +973,6 @@ class Builder : public _InternalBuilderBase {
   //   ._().Condition<A>()
   //   .End();
   auto& Not() { return C<InvertNode>("Not"); }
-
   // Creates a invert condition of given Condition class.
   // Code exapmle::
   //   root
@@ -1000,7 +984,6 @@ class Builder : public _InternalBuilderBase {
   auto& Not(ConditionArgs... args) {
     return C<InvertNode>("Not", make<Condition>(false, std::forward<ConditionArgs>(args)...));
   }
-
   // Repeat creates a RepeatNode.
   // It will repeat the decorated node for exactly n times.
   // Providing n=-1 means to repeat forever.
@@ -1011,14 +994,12 @@ class Builder : public _InternalBuilderBase {
   //   ._().Action<A>()
   //   .End();
   auto& Repeat(int n) { return C<RepeatNode>(n, "Repeat"); }
-
   // Alias to Repeat.
   // Code exapmle::
   //   root
   //   .Loop(3)
   //   ._().Action<A>();
   auto& Loop(int n) { return C<RepeatNode>(n, "Loop"); }
-
   // Timeout creates a TimeoutNode.
   // It executes the decorated node for at most given duration.
   // Code exapmle::
@@ -1027,7 +1008,6 @@ class Builder : public _InternalBuilderBase {
   //   ._().Action<A>()
   //   .End();
   auto& Timeout(std::chrono::milliseconds duration) { return C<TimeoutNode>(duration, "Timeout"); }
-
   // Delay creates a DelayNode.
   // Wait for given duration before execution of decorated node.
   // Code exapmle::
@@ -1036,7 +1016,6 @@ class Builder : public _InternalBuilderBase {
   //   ._().Action<A>()
   //   .End();
   auto& Delay(std::chrono::milliseconds duration) { return C<DelayNode>(duration, "Delay"); }
-
   // Retry creates a RetryNode.
   // It executes the decorated node for at most n times.
   // A retry will only be initiated if the decorated node fails.
@@ -1047,12 +1026,10 @@ class Builder : public _InternalBuilderBase {
   //   ._().Action<A>()
   //   .End();
   auto& Retry(int n, std::chrono::milliseconds interval) { return C<RetryNode>(n, interval, "Retry"); }
-
   // Alias for Retry(-1, interval)
   auto& RetryForever(std::chrono::milliseconds interval) {
     return C<RetryNode>(-1, interval, "RetryForever");
   }
-
   // If creates a ConditionalRunNode.
   // It executes the decorated node only if the condition goes true.
   // Code example::
@@ -1065,14 +1042,12 @@ class Builder : public _InternalBuilderBase {
     auto condition = make<Condition>(false, std::forward<ConditionArgs>(args)...);
     return C<ConditionalRunNode>(std::move(condition), "If");
   }
-
   // If creates a ConditionalRunNode from lambda function.
   // Code example::
   //  root
   //  .If([=](const Context& ctx) { return false; })
   //  .End();
   auto& If(ConditionNode::Checker checker) { return If<ConditionNode>(checker); }
-
   // Switch is just an alias to Selector.
   // Code example::
   //   root
@@ -1085,17 +1060,14 @@ class Builder : public _InternalBuilderBase {
   //   ._()._().Action<D>()
   //   .End();
   auto& Switch() { return C<SelectorNode>("Switch"); }
-
   // Stateful version `Switch` based on StatefulSelectorNode.
   auto& StatefulSwitch() { return C<StatefulSelectorNode>("Switch*"); }
-
   // Alias to If, for working alongs with Switch.
   template <TCondition Condition, typename... ConditionArgs>
   auto& Case(ConditionArgs&&... args) {
     auto condition = make<Condition>(false, std::forward<ConditionArgs>(args)...);
     return C<ConditionalRunNode>(std::move(condition), "Case");
   }
-
   // Case creates a ConditionalRunNode from lambda function.
   auto& Case(ConditionNode::Checker checker) { return Case<ConditionNode>(checker); }
 

--- a/bt.h
+++ b/bt.h
@@ -422,17 +422,13 @@ class _MixedQueueHelper {
   };
 
  private:
-  // use a pre-allocated vector instead of a std::queue
-  // The q1 will be pushed all and then poped all, so a simple vector is enough,
-  // and neither needs a circular queue.
-  // And here we use a pointer, allowing temporarily replace q1's container from
-  // outside existing container.
+  // use a pre-allocated vector instead of a std::queue, q1 will be pushed all and then poped all,
+  // so a simple vector is enough, and neither needs a circular queue.
+  // And here we use a pointer, allowing temporarily replace q1's container from outside existing container.
   std::vector<int>* q1;
   std::vector<int> q1Container;
   int q1Front = 0;
-
   _priority_queue<int, std::vector<int>> q2;
-
   bool use1;  // using q1? otherwise q2
 
  public:
@@ -1076,7 +1072,6 @@ class Builder : public _InternalBuilderBase {
 
   // Attach a sub behavior tree into this tree.
   // Code example::
-  //
   //    bt::Tree subtree;
   //    subtree
   //      .Action<B>()

--- a/changelog
+++ b/changelog
@@ -4,6 +4,7 @@
 * Separates to bt.h and bt.cc.
 * Remove template Clock, use std::chrono::steady_clock.
 * Use printf instead of iostream
+* Rename project to `bt.cc`
 
 0.3.5
 -----

--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+0.4.0
+-----
+
+* Separates to bt.h and bt.cc.
+* Remove template Clock, use std::chrono::steady_clock.
+
 0.3.5
 -----
 

--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@
 
 * Separates to bt.h and bt.cc.
 * Remove template Clock, use std::chrono::steady_clock.
+* Use printf instead of iostream
 
 0.3.5
 -----

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,4 +7,4 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include_directories("..")
 
 # Targets
-add_executable(bt_example main.cc)
+add_executable(bt_example main.cc ../bt.cc)

--- a/example/main.cc
+++ b/example/main.cc
@@ -1,4 +1,5 @@
 #include <cstdlib>
+#include <thread>
 
 #include "bt.h"
 using namespace std::chrono_literals;

--- a/example/onsignal/CMakeLists.txt
+++ b/example/onsignal/CMakeLists.txt
@@ -7,4 +7,4 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include_directories("../..")
 
 # Targets
-add_executable(bt_example_onsignal main.cc)
+add_executable(bt_example_onsignal main.cc ../../bt.cc)

--- a/example/onsignal/main.cc
+++ b/example/onsignal/main.cc
@@ -1,5 +1,4 @@
 #include <any>
-#include <chrono>
 #include <cstdlib>
 #include <initializer_list>
 #include <iostream>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,8 +12,8 @@ include_directories(".." ".")
 find_package(Catch2 CONFIG REQUIRED)
 
 # Targets
-file(GLOB TEST_SOURCES *_test.cc)
-file(GLOB BENCHMARK_SOURCES *_benchmark.cc)
+file(GLOB TEST_SOURCES *_test.cc ../bt.cc)
+file(GLOB BENCHMARK_SOURCES *_benchmark.cc ../bt.cc)
 add_executable(bt_tests ${TEST_SOURCES})
 add_executable(bt_benchmark ${BENCHMARK_SOURCES})
 

--- a/tests/condition_test.cc
+++ b/tests/condition_test.cc
@@ -24,7 +24,6 @@ TEST_CASE("Condition/1", "[simplest condition - constructed from template]") {
 
   // Tick#1
   root.BindTreeBlob(e.blob);
-  std::cout << "tick1" << std::endl;
   ++ctx.seq;
   root.Tick(ctx);
   // A should not started.
@@ -32,7 +31,6 @@ TEST_CASE("Condition/1", "[simplest condition - constructed from template]") {
   REQUIRE(bb->statusA == bt::Status::UNDEFINED);
   root.UnbindTreeBlob();
 
-  std::cout << "tick2" << std::endl;
   // Tick#2: Make C true.
   root.BindTreeBlob(e.blob);
   bb->shouldC = true;
@@ -45,7 +43,6 @@ TEST_CASE("Condition/1", "[simplest condition - constructed from template]") {
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   root.UnbindTreeBlob();
 
-  std::cout << "tick3" << std::endl;
   // Tick#3: Make A Success.
   root.BindTreeBlob(e.blob);
   bb->shouldA = bt::Status::SUCCESS;

--- a/tests/delay_test.cc
+++ b/tests/delay_test.cc
@@ -8,7 +8,7 @@
 using namespace std::chrono_literals;
 
 TEMPLATE_TEST_CASE("Delay/1", "[simple delay]", Entity,
-                   (EntityFixedBlob<16, sizeof(bt::DelayNode<>::Blob)>)) {
+                   (EntityFixedBlob<16, sizeof(bt::DelayNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);

--- a/tests/delay_test.cc
+++ b/tests/delay_test.cc
@@ -7,8 +7,7 @@
 
 using namespace std::chrono_literals;
 
-TEMPLATE_TEST_CASE("Delay/1", "[simple delay]", Entity,
-                   (EntityFixedBlob<16, sizeof(bt::DelayNode::Blob)>)) {
+TEMPLATE_TEST_CASE("Delay/1", "[simple delay]", Entity, (EntityFixedBlob<16, sizeof(bt::DelayNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -26,7 +25,9 @@ TEMPLATE_TEST_CASE("Delay/1", "[simple delay]", Entity,
   REQUIRE(bb->counterA == 0);
   // Tick#1: A is not started.
   root.BindTreeBlob(e.blob);
-  ++ctx.seq;root.Tick(ctx);;
+  ++ctx.seq;
+  root.Tick(ctx);
+  ;
   REQUIRE(bb->counterA == 0);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   root.UnbindTreeBlob();
@@ -36,7 +37,9 @@ TEMPLATE_TEST_CASE("Delay/1", "[simple delay]", Entity,
 
   // Tick#2: A is started.
   root.BindTreeBlob(e.blob);
-  ++ctx.seq;root.Tick(ctx);;
+  ++ctx.seq;
+  root.Tick(ctx);
+  ;
   REQUIRE(bb->counterA == 1);
   root.UnbindTreeBlob();
 }

--- a/tests/retry_test.cc
+++ b/tests/retry_test.cc
@@ -24,13 +24,15 @@ TEMPLATE_TEST_CASE("Retry/1", "[simple retry success]", Entity,
   root.BindTreeBlob(e.blob);
 
   // Tick#1
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: Makes A success.
   bb->shouldA = bt::Status::SUCCESS;
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
 
@@ -55,13 +57,15 @@ TEMPLATE_TEST_CASE("Retry/2", "[simple retry final failure]", Entity,
   root.BindTreeBlob(e.blob);
 
   // Tick#1
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: Makes A failure
   bb->shouldA = bt::Status::FAILURE;
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
@@ -69,15 +73,18 @@ TEMPLATE_TEST_CASE("Retry/2", "[simple retry final failure]", Entity,
   for (int i = 1; i <= 2; i++) {
     std::this_thread::sleep_for(30ms);
     bb->shouldA = bt::Status::RUNNING;
-    ++ctx.seq;root.Tick(ctx);
+    ++ctx.seq;
+    root.Tick(ctx);
     REQUIRE(root.LastStatus() == bt::Status::RUNNING);
     bb->shouldA = bt::Status::FAILURE;
-    ++ctx.seq;root.Tick(ctx);
+    ++ctx.seq;
+    root.Tick(ctx);
     REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   }
 
   // Next the whole tree should failure.
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
 
   root.UnbindTreeBlob();
@@ -100,20 +107,23 @@ TEMPLATE_TEST_CASE("Retry/3", "[simple retry final success ]", Entity,
   root.BindTreeBlob(e.blob);
 
   // Tick#1
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: Makes A failure
   bb->shouldA = bt::Status::FAILURE;
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#3: Makes A ok.
   std::this_thread::sleep_for(30ms);
   bb->shouldA = bt::Status::SUCCESS;
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
   root.UnbindTreeBlob();
 }
@@ -136,13 +146,15 @@ TEMPLATE_TEST_CASE("Retry/4", "[simple retry forever ]", Entity,
   root.BindTreeBlob(e.blob);
 
   // Tick#1
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: Makes A failure
   bb->shouldA = bt::Status::FAILURE;
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
@@ -150,7 +162,8 @@ TEMPLATE_TEST_CASE("Retry/4", "[simple retry forever ]", Entity,
   for (int i = 0; i < 30; i++) {
     std::this_thread::sleep_for(1ms);
     bb->shouldA = bt::Status::FAILURE;
-    ++ctx.seq;root.Tick(ctx);
+    ++ctx.seq;
+    root.Tick(ctx);
     REQUIRE(root.LastStatus() == bt::Status::RUNNING);
   }
   root.UnbindTreeBlob();

--- a/tests/retry_test.cc
+++ b/tests/retry_test.cc
@@ -8,7 +8,7 @@
 using namespace std::chrono_literals;
 
 TEMPLATE_TEST_CASE("Retry/1", "[simple retry success]", Entity,
-                   (EntityFixedBlob<16, sizeof(bt::RetryNode<>::Blob)>)) {
+                   (EntityFixedBlob<16, sizeof(bt::RetryNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -38,7 +38,7 @@ TEMPLATE_TEST_CASE("Retry/1", "[simple retry success]", Entity,
 }
 
 TEMPLATE_TEST_CASE("Retry/2", "[simple retry final failure]", Entity,
-                   (EntityFixedBlob<16, sizeof(bt::RetryNode<>::Blob)>)) {
+                   (EntityFixedBlob<16, sizeof(bt::RetryNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -84,7 +84,7 @@ TEMPLATE_TEST_CASE("Retry/2", "[simple retry final failure]", Entity,
 }
 
 TEMPLATE_TEST_CASE("Retry/3", "[simple retry final success ]", Entity,
-                   (EntityFixedBlob<16, sizeof(bt::RetryNode<>::Blob)>)) {
+                   (EntityFixedBlob<16, sizeof(bt::RetryNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -119,7 +119,7 @@ TEMPLATE_TEST_CASE("Retry/3", "[simple retry final success ]", Entity,
 }
 
 TEMPLATE_TEST_CASE("Retry/4", "[simple retry forever ]", Entity,
-                   (EntityFixedBlob<16, sizeof(bt::RetryNode<>::Blob)>)) {
+                   (EntityFixedBlob<16, sizeof(bt::RetryNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);

--- a/tests/timeout_test.cc
+++ b/tests/timeout_test.cc
@@ -8,7 +8,7 @@
 using namespace std::chrono_literals;
 
 TEMPLATE_TEST_CASE("Timeout/1", "[simple timeout success]", Entity,
-                   (EntityFixedBlob<16, sizeof(bt::TimeoutNode<>::Blob)>)) {
+                   (EntityFixedBlob<16, sizeof(bt::TimeoutNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -37,7 +37,7 @@ TEMPLATE_TEST_CASE("Timeout/1", "[simple timeout success]", Entity,
 }
 
 TEMPLATE_TEST_CASE("Timeout/2", "[simple timeout failure]", Entity,
-                   (EntityFixedBlob<16, sizeof(bt::TimeoutNode<>::Blob)>)) {
+                   (EntityFixedBlob<16, sizeof(bt::TimeoutNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);
@@ -66,7 +66,7 @@ TEMPLATE_TEST_CASE("Timeout/2", "[simple timeout failure]", Entity,
 }
 
 TEMPLATE_TEST_CASE("Timeout/3", "[simple timeout timedout]", Entity,
-                   (EntityFixedBlob<16, sizeof(bt::TimeoutNode<>::Blob)>)) {
+                   (EntityFixedBlob<16, sizeof(bt::TimeoutNode::Blob)>)) {
   bt::Tree root;
   auto bb = std::make_shared<Blackboard>();
   bt::Context ctx(bb);

--- a/tests/timeout_test.cc
+++ b/tests/timeout_test.cc
@@ -24,13 +24,15 @@ TEMPLATE_TEST_CASE("Timeout/1", "[simple timeout success]", Entity,
   TestType e;
   root.BindTreeBlob(e.blob);
   // Tick#1: A is not started.
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: Makes A success.
   bb->shouldA = bt::Status::SUCCESS;
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(root.LastStatus() == bt::Status::SUCCESS);
   root.UnbindTreeBlob();
@@ -53,13 +55,15 @@ TEMPLATE_TEST_CASE("Timeout/2", "[simple timeout failure]", Entity,
   TestType e;
   root.BindTreeBlob(e.blob);
   // Tick#1: A is not started.
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: Makes A failure.
   bb->shouldA = bt::Status::FAILURE;
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 2);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
   root.UnbindTreeBlob();
@@ -82,13 +86,15 @@ TEMPLATE_TEST_CASE("Timeout/3", "[simple timeout timedout]", Entity,
   TestType e;
   root.BindTreeBlob(e.blob);
   // Tick#1: A is not started.
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::RUNNING);
 
   // Tick#2: should timeout
   std::this_thread::sleep_for(110ms);
-  ++ctx.seq;root.Tick(ctx);
+  ++ctx.seq;
+  root.Tick(ctx);
   REQUIRE(bb->counterA == 1);
   REQUIRE(root.LastStatus() == bt::Status::FAILURE);
   root.UnbindTreeBlob();


### PR DESCRIPTION
- Separate cpp with header
- remove useless cout in tests
- Move internal implements to builder base
- Fix tests
- reformat
- shrink lines of code
- 0.4.0: sperate cpp files
- use printf instead of cout
