### PR TITLE
0.4.2: Enable Move for base Node class 

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+0.4.2
+-----
+
+* Enable default move constructor and move assigment generation for class Node.
+* Remove unnessary destructor for class Builder.
+
 0.4.1
 -----
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,4 +18,7 @@ run:
 clean:
 	make -C build clean
 
+run-benchmark:
+	cd build && ./bt_benchmark
+
 .PHONY: build

--- a/tests/misc_test.cc
+++ b/tests/misc_test.cc
@@ -1,0 +1,19 @@
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+
+#include "types.h"
+
+TEST_CASE("Misc/1", "[any node should be movable]") {
+  J j1{"a really looooooooong name to avoid the string SSO optimization",
+       "a really looooooooong s string to avoid the string SSO optimization"};
+  auto addr11 = static_cast<void*>(j1.s.data());
+  auto addr12 = static_cast<const void*>(j1.Name().data());
+  J j2(std::move(j1));
+  auto addr21 = static_cast<void*>(j2.s.data());
+  auto addr22 = static_cast<const void*>(j2.Name().data());
+  // The two address of underlying data should be the same if the movement successful done.
+  REQUIRE(addr11 == addr21);
+  // And the base class Node's underlying storage should also movable.
+  REQUIRE(addr12 == addr22);
+}

--- a/tests/types.h
+++ b/tests/types.h
@@ -1,3 +1,4 @@
+#include <string>
 
 #include "bt.h"
 
@@ -145,4 +146,10 @@ class I : public bt::ActionNode {
     auto bb = std::any_cast<std::shared_ptr<Blackboard>>(ctx.data);
     return bb->shouldPriorityI;
   }
+};
+
+class J : public bt::ActionNode {
+ public:
+  std::string s;
+  J(const std::string& name, const std::string& s) : bt::ActionNode(name), s(s) {}
 };


### PR DESCRIPTION
- **0.4.2: Enable move semantics for base Node class and  remove unnessary   destructor for class Builder**
- **Add run-benchmark target to Makefile**
- **Add a simple unittest for Node base class movable**
